### PR TITLE
afisha migrations dependencies fix

### DIFF
--- a/apps/afisha/migrations/0004_auto_20211007_1713.py
+++ b/apps/afisha/migrations/0004_auto_20211007_1713.py
@@ -8,7 +8,7 @@ import django.utils.timezone
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('library', '0002_auto_20211002_2212'),
+        ('library', '0002_auto_20211004_1737'),
         ('afisha', '0003_baseevent'),
     ]
 


### PR DESCRIPTION
В зависимостях последней миграции в афише была ссылка на миграцию из library, которая была пересоздана, в следствии чего сменила название (пока PR афиши был на ревью).