### PR TITLE
fix urls path and fix volunteer fibric

### DIFF
--- a/apps/info/tests/factories.py
+++ b/apps/info/tests/factories.py
@@ -57,7 +57,8 @@ class VolunteerFactory(factory.django.DjangoModelFactory):
         Person.objects.filter(email__isnull=False).exclude(image__exact="")
     )
     year = factory.Faker("random_int", min=2018, max=2021, step=1)
-    review = factory.Faker("text", max_nb_chars=1000, locale="ru_RU")
+    review_title = factory.Faker("text", max_nb_chars=50, locale="ru_RU")
+    review_text = factory.Faker("text", max_nb_chars=1000, locale="ru_RU")
 
 
 class FestivalTeamFactory(factory.django.DjangoModelFactory):

--- a/apps/info/urls.py
+++ b/apps/info/urls.py
@@ -13,12 +13,7 @@ from apps.static_pages.views import StaticPagesView
 
 about_festival_urls = [
     path(
-        "<slug:static_page_url>/",
-        StaticPagesView.as_view(),
-        name="static_page",
-    ),
-    path(
-        "festival-teams/",
+        "team/",
         FestivalTeamsViewSet.as_view(),
         name="festival-teams",
     ),
@@ -31,6 +26,11 @@ about_festival_urls = [
         "volunteers/",
         VolunteersViewSet.as_view(),
         name="volunteers",
+    ),
+    path(
+        "<slug:static_page_url>/",
+        StaticPagesView.as_view(),
+        name="static_page",
     ),
 ]
 


### PR DESCRIPTION
**Закину в PR, чтобы не забыть и не потерять эту проблемку.**

1. АПИ на ендпоинты info/about-festival/ не работало по причине неправильного расположения.
```"<slug:static_page_url>/"``` блокировал ендпоинты под собой.

2. Так же поправил фабрику для волонтеров