### PR TITLE
fixed command name

### DIFF
--- a/apps/core/management/commands/set_perms.py
+++ b/apps/core/management/commands/set_perms.py
@@ -6,7 +6,7 @@ from django.core.management.base import BaseCommand, CommandError
 fixture = "apps/core/management/commands/fixture/fixture_group_perms.json"
 
 
-class SetUsersPermissionsCommand(BaseCommand):
+class Command(BaseCommand):
     help = (
         "Устанавливает права для групп пользователей Администратор и Редактор"
     )


### PR DESCRIPTION
Класс SetUserPermissionsCommand переименован обратно в Command. С кастомным названием не работает. 
"...The closepoll.py module has only one requirement – **it must define a class Command** that extends BaseCommand or one of its subclasses..."
https://docs.djangoproject.com/en/dev/howto/custom-management-commands/