### PR TITLE
Рефакторинг festivals/years

### DIFF
--- a/apps/info/serializers/__init__.py
+++ b/apps/info/serializers/__init__.py
@@ -1,4 +1,4 @@
-from .festival import FestivalSerializer
+from .festival import FestivalSerializer, YearsSerializer
 from .festivalteams import FestivalTeamsSerializer
 from .partners import PartnerSerializer
 from .question import QuestionSerializer
@@ -6,10 +6,11 @@ from .sponsors import SponsorSerializer
 from .volunteers import VolunteersSerializer
 
 __all__ = (
-    "PartnerSerializer",
-    "QuestionSerializer",
-    "SponsorSerializer",
-    "FestivalTeamsSerializer",
-    "VolunteersSerializer",
-    "FestivalSerializer",
+    PartnerSerializer,
+    QuestionSerializer,
+    SponsorSerializer,
+    FestivalTeamsSerializer,
+    VolunteersSerializer,
+    FestivalSerializer,
+    YearsSerializer,
 )

--- a/apps/info/serializers/festival.py
+++ b/apps/info/serializers/festival.py
@@ -8,3 +8,7 @@ class FestivalSerializer(serializers.ModelSerializer):
         model = Festival
         exclude = ("created", "modified")
         depth = 1
+
+
+class YearsSerializer(serializers.Serializer):
+    years = serializers.ListField(child=serializers.IntegerField())

--- a/apps/info/tests/conftest.py
+++ b/apps/info/tests/conftest.py
@@ -11,7 +11,7 @@ from apps.info.tests.factories import (
 )
 
 FESTIVAL_URL_NAME = "festivals"
-FESTIVAL_YEARS_URL = reverse("festivals_years")
+FESTIVAL_YEARS_URL = reverse("festivals-years")
 TEAMS_URL = reverse("festival-teams")
 TEAMS_URL_FILTER = TEAMS_URL + "?team="
 SPONSORS_URL = reverse("sponsors")

--- a/apps/info/urls.py
+++ b/apps/info/urls.py
@@ -1,30 +1,30 @@
 from django.urls import include, path
 
 from apps.info.views import (
-    FestivalTeamsViewSet,
-    FestivalViewSet,
-    PartnersViewSet,
-    QuestionCreateAPI,
-    SponsorViewSet,
-    VolunteersViewSet,
-    festivals_years,
+    FestivalAPIView,
+    FestivalTeamsAPIView,
+    FestivalYearsAPIView,
+    PartnersAPIView,
+    QuestionCreateAPIView,
+    SponsorsAPIView,
+    VolunteersAPIView,
 )
 from apps.static_pages.views import StaticPagesView
 
 about_festival_urls = [
     path(
         "team/",
-        FestivalTeamsViewSet.as_view(),
+        FestivalTeamsAPIView.as_view(),
         name="festival-teams",
     ),
     path(
         "sponsors/",
-        SponsorViewSet.as_view(),
+        SponsorsAPIView.as_view(),
         name="sponsors",
     ),
     path(
         "volunteers/",
-        VolunteersViewSet.as_view(),
+        VolunteersAPIView.as_view(),
         name="volunteers",
     ),
     path(
@@ -37,12 +37,12 @@ about_festival_urls = [
 info_urls = [
     path(
         "festivals/years/",
-        festivals_years,
-        name="festivals_years",
+        FestivalYearsAPIView.as_view(),
+        name="festivals-years",
     ),
     path(
         "festivals/<int:year>/",
-        FestivalViewSet.as_view(),
+        FestivalAPIView.as_view(),
         name="festivals",
     ),
     path(
@@ -51,12 +51,12 @@ info_urls = [
     ),
     path(
         "partners/",
-        PartnersViewSet.as_view(),
+        PartnersAPIView.as_view(),
         name="partners",
     ),
     path(
         "questions/",
-        QuestionCreateAPI.as_view(),
+        QuestionCreateAPIView.as_view(),
         name="questions",
     ),
 ]

--- a/apps/info/views/__init__.py
+++ b/apps/info/views/__init__.py
@@ -1,16 +1,16 @@
-from .festival import FestivalViewSet, festivals_years
-from .festivalteams import FestivalTeamsViewSet
-from .partners import PartnersViewSet
-from .question import QuestionCreateAPI
-from .sponsors import SponsorViewSet
-from .volunteers import VolunteersViewSet
+from .festival import FestivalAPIView, FestivalYearsAPIView
+from .festivalteams import FestivalTeamsAPIView
+from .partners import PartnersAPIView
+from .question import QuestionCreateAPIView
+from .sponsors import SponsorsAPIView
+from .volunteers import VolunteersAPIView
 
 __all__ = (
-    "QuestionCreateAPI",
-    "PartnersViewSet",
-    "SponsorViewSet",
-    "FestivalTeamsViewSet",
-    "VolunteersViewSet",
-    "FestivalViewSet",
-    "festivals_years",
+    FestivalAPIView,
+    FestivalTeamsAPIView,
+    FestivalYearsAPIView,
+    PartnersAPIView,
+    QuestionCreateAPIView,
+    SponsorsAPIView,
+    VolunteersAPIView,
 )

--- a/apps/info/views/festival.py
+++ b/apps/info/views/festival.py
@@ -1,22 +1,29 @@
-from django.http import JsonResponse
-from rest_framework import status
-from rest_framework.decorators import api_view
+from drf_spectacular.utils import extend_schema
 from rest_framework.generics import RetrieveAPIView
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from apps.info.models import Festival
-from apps.info.serializers import FestivalSerializer
+from apps.info.serializers import FestivalSerializer, YearsSerializer
 
 
-class FestivalViewSet(RetrieveAPIView):
+class FestivalAPIView(RetrieveAPIView):
+    """Returns a festival info and statistics.
+
+    URL detailed lookup suffix is `year`."""
+
     queryset = Festival.objects.all()
     serializer_class = FestivalSerializer
     lookup_field = "year"
     pagination_class = None
 
 
-@api_view(["GET"])
-def festivals_years(request):
-    data = list(
-        festival["year"] for festival in Festival.objects.values("year")
-    )
-    return JsonResponse({"years": data}, status=status.HTTP_200_OK)
+class FestivalYearsAPIView(APIView):
+    """Returns a list of the years in which the festival took place."""
+
+    @extend_schema(responses=YearsSerializer)
+    def get(self, request):
+        years_values_list = Festival.objects.values_list("year", flat=True)
+        years_instance = {"years": years_values_list}
+        years_serializer = YearsSerializer(instance=years_instance)
+        return Response(years_serializer.data)

--- a/apps/info/views/festivalteams.py
+++ b/apps/info/views/festivalteams.py
@@ -4,7 +4,7 @@ from apps.info.models import FestivalTeam
 from apps.info.serializers import FestivalTeamsSerializer
 
 
-class FestivalTeamsViewSet(ListAPIView):
+class FestivalTeamsAPIView(ListAPIView):
     queryset = FestivalTeam.objects.all()
     serializer_class = FestivalTeamsSerializer
     filterset_fields = ("team",)

--- a/apps/info/views/partners.py
+++ b/apps/info/views/partners.py
@@ -4,7 +4,7 @@ from apps.info.models import Partner
 from apps.info.serializers import PartnerSerializer
 
 
-class PartnersViewSet(ListAPIView):
+class PartnersAPIView(ListAPIView):
     queryset = Partner.objects.all()
     serializer_class = PartnerSerializer
     filterset_fields = ("type",)

--- a/apps/info/views/question.py
+++ b/apps/info/views/question.py
@@ -4,7 +4,7 @@ from apps.info.serializers.question import QuestionSerializer
 from apps.info.utils import send_question
 
 
-class QuestionCreateAPI(generics.CreateAPIView):
+class QuestionCreateAPIView(generics.CreateAPIView):
     serializer_class = QuestionSerializer
 
     def perform_create(self, serializer):

--- a/apps/info/views/sponsors.py
+++ b/apps/info/views/sponsors.py
@@ -4,7 +4,7 @@ from apps.info.models import Sponsor
 from apps.info.serializers import SponsorSerializer
 
 
-class SponsorViewSet(ListAPIView):
+class SponsorsAPIView(ListAPIView):
     queryset = Sponsor.objects.all()
     serializer_class = SponsorSerializer
     pagination_class = None

--- a/apps/info/views/volunteers.py
+++ b/apps/info/views/volunteers.py
@@ -4,7 +4,7 @@ from apps.info.models import Volunteer
 from apps.info.serializers import VolunteersSerializer
 
 
-class VolunteersViewSet(ListAPIView):
+class VolunteersAPIView(ListAPIView):
     queryset = Volunteer.objects.all()
     serializer_class = VolunteersSerializer
     filterset_fields = ("year",)


### PR DESCRIPTION
API festivals/years
- структура ответа не поменялась
- теперь используем APIView класс
- ответ формируется с помощью сериализатора
- благодаря сериалазтору с документацией теперь порядок

Другие API в info
- названия API классов изменены с ViewSet-ов на APIView. Вьюсеты другая сущность с другим набором методов, которых у наших классов нет. Так будет меньше заблуждение что можно с ними делать.


Когда создаёте PR, убедитесь, что:

- [ ] вы проверили обновления в [брифе](https://www.notion.so/00f5d5a6d39e426fa1ea7ab69b694f07)
- [ ] синхронизировали изменения кода с [ER-диаграммой базы данных](https://drive.google.com/file/d/1RCIPaEgaLUSqek3znd38VPCKSzOlmJFy/view) связей моделей
- [ ] тесты все пройдены и нет конфликтов
- [ ] созданы необходимые миграции

Когда ваш PR смержен:

- [ ] если у вас были изменения в API, сообщите об этом команде Фронта, им это важно знать!
