### PR TITLE
Bugfix/adaptive images in admin

### DIFF
--- a/apps/core/mixins.py
+++ b/apps/core/mixins.py
@@ -12,12 +12,16 @@ class AdminImagePreview:
 
     @admin.display(description="Превью")
     def image_preview_change_page(self, obj):
-        return format_html('<img src="{}" width="600" height="300" />'.format(obj.image.url))
+        return format_html(
+            '<img src="{}" width="600" height="300" style="object-fit: contain;" />'.format(obj.image.url)
+        )
 
     @admin.display(description="Превью")
     def image_preview_list_page(self, obj):
         if obj.image:
-            return format_html('<img src="{}" width="100" height="50" />'.format(obj.image.url))
+            return format_html(
+                '<img src="{}" width="100" height="50" style="object-fit: contain;" />'.format(obj.image.url)
+            )
 
 
 class HideOnNavPanelAdminModelMixin:

--- a/apps/info/tests/factories.py
+++ b/apps/info/tests/factories.py
@@ -122,5 +122,5 @@ class PlaceFactory(factory.django.DjangoModelFactory):
     name = factory.Faker("word", locale="ru_RU")
     description = factory.Faker("sentence", locale="ru_RU")
     city = factory.Faker("city", locale="ru_RU")
-    address = factory.Faker("address", locale="ru_RU")
+    address = factory.Faker("street_address", locale="ru_RU")
     map_link = factory.Faker("url", locale="ru_RU")


### PR DESCRIPTION
У нас падала фабрика - Places. Связано с максимальной длиной адреса (поменяли на 50). Фабрика генерила больше

Добавил минимальную адаптивность в изображения (у нас они растягивались, что не красиво).
Вообще подумал подключить Bootstrap, но не уверен насколько это правильно, ради просмотра изображий будет загружаться большой css
