### PR TITLE
add test job in develop pipeline

### DIFF
--- a/.github/workflows/backend_deploy.yaml
+++ b/.github/workflows/backend_deploy.yaml
@@ -18,9 +18,30 @@ defaults:
     working-directory: .
 
 jobs:
+  tests:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+    -
+      name: Check out the repo
+      uses: actions/checkout@v2
+    -
+      name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    -
+      name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements/dev.txt
+    -
+      name: Test with pytest
+      run: pytest
   build-and-push-image-to-github-packages:
     name: Push Docker image to GitHub Packages
     runs-on: ubuntu-latest
+    needs: tests
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Это ПР возвращает тесты при деплое на сервер (пайплайн develop). Произошёл конфликт миграций.
Решено было вновь добавить, чтобы не было деплоя с плохими миграциями.
