### PR TITLE
delete quotes from pdf filename

### DIFF
--- a/apps/info/utils.py
+++ b/apps/info/utils.py
@@ -32,7 +32,7 @@ def send_question(serializer):
 def get_pdf_response(press_release_instance, path_to_font):
     press_release_year = press_release_instance.festival.year
     response = HttpResponse(content_type="application/pdf")
-    response["Content-Disposition"] = f"attachment; filename='press-release_{press_release_year}.pdf'"
+    response["Content-Disposition"] = f"attachment; filename=press-release_{press_release_year}.pdf"
     template = get_template("press_release.html")
     content = template.render(
         {


### PR DESCRIPTION
При загрузке пресс-релиза, файл сохранялся в кавычках, исправлено.