### PR TITLE
change setiings of the django degug toolbar for docker use

### DIFF
--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -26,7 +26,6 @@ DEBUG_TOOLBAR_CONFIG = {
     "DISABLE_PANELS": ["debug_toolbar.panels.redirects.RedirectsPanel"],
     "SHOW_COLLAPSED": True,
     "SHOW_TEMPLATE_CONTEXT": True,
-    "SHOW_TOOLBAR_CALLBACK": lambda _request: DEBUG,
 }
 
 INTERNAL_IPS = ["127.0.0.1", "10.0.2.2"]

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -26,8 +26,22 @@ DEBUG_TOOLBAR_CONFIG = {
     "DISABLE_PANELS": ["debug_toolbar.panels.redirects.RedirectsPanel"],
     "SHOW_COLLAPSED": True,
     "SHOW_TEMPLATE_CONTEXT": True,
-    "SHOW_TOOLBAR_CALLBACK": lambda _request: DEBUG,
 }
+
+INTERNAL_IPS = ["127.0.0.1", "10.0.2.2"]
+
+# Add in INTERNAL_IPS internal IP of the docker container if DEGUG == True.
+if env("DEBUG"):
+    import socket
+
+    hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
+    INTERNAL_IPS += [".".join(ip.split(".")[:-1] + ["1"]) for ip in ips]
+    try:
+        _, _, ips = socket.gethostbyname_ex("node")
+        INTERNAL_IPS.extend(ips)
+    except socket.gaierror:
+        # The node container isn't started (yet?)
+        pass
 
 # Use PostgreSQL
 # ------------------------------------------------------------------------------

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -26,6 +26,7 @@ DEBUG_TOOLBAR_CONFIG = {
     "DISABLE_PANELS": ["debug_toolbar.panels.redirects.RedirectsPanel"],
     "SHOW_COLLAPSED": True,
     "SHOW_TEMPLATE_CONTEXT": True,
+    "SHOW_TOOLBAR_CALLBACK": lambda _request: DEBUG,
 }
 
 INTERNAL_IPS = ["127.0.0.1", "10.0.2.2"]

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -73,11 +73,5 @@ ANYMAIL = {
 }
 
 # https://anymail.readthedocs.io/en/stable/installation/?highlight=SERVER_EMAIL#configuring-django-s-email-backend
-SERVER_EMAIL = env(
-    "SERVER_EMAIL",
-    default="service@lyubimovka.ru",
-)
-DEFAULT_FROM_EMAIL = env(
-    "DEFAULT_FROM_EMAIL",
-    default="lyubimovka@lyubimovka.ru",
-)
+SERVER_EMAIL = env("SERVER_EMAIL", default=None)
+DEFAULT_FROM_EMAIL = env("DEFAULT_FROM_EMAIL", default=None)

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -47,11 +47,5 @@ ANYMAIL = {
 }
 
 # https://anymail.readthedocs.io/en/stable/installation/?highlight=SERVER_EMAIL#configuring-django-s-email-backend
-SERVER_EMAIL = env(
-    "SERVER_EMAIL",
-    default="service@lyubimovka.ru",
-)
-DEFAULT_FROM_EMAIL = env(
-    "DEFAULT_FROM_EMAIL",
-    default="lyubimovka@lyubimovka.ru",
-)
+SERVER_EMAIL = env("SERVER_EMAIL", default=None)
+DEFAULT_FROM_EMAIL = env("DEFAULT_FROM_EMAIL", default=None)

--- a/infra_deploy/test/swag/swag_nginx_test.conf
+++ b/infra_deploy/test/swag/swag_nginx_test.conf
@@ -36,7 +36,7 @@ server {
         root /config/test/;
     }
 
-    location ~^/(api|admin) {
+    location ~^/(api|admin|__debug__) {
         include /config/nginx/proxy.conf;
         set $upstream_app backend;
         set $upstream_port 8000;


### PR DESCRIPTION
Django degug toolbar не взлетел в предыдущем ПР.
Панель отображается, но запросы не проходят (ошибка 404)
Почти как [тут](https://stackoverflow.com/questions/44044811/clicking-on-django-debug-toolbar-tabs-results-in-404-not-found-error)
Вероятнее всего это связано с AJAX запросами на стороне браузера, которые не проходят на бэк.
В django cookiecutter описано такое решение, в отличие от моего предыдущего здесь прописываются внутренние IP. Скорее все дело в них.