### PR TITLE
Bugfix: get_pagingated_response util returns absolute url

### DIFF
--- a/apps/articles/tests/blog_items/tests_views/test_blog_item_list.py
+++ b/apps/articles/tests/blog_items/tests_views/test_blog_item_list.py
@@ -91,3 +91,11 @@ def test_blog_item_list_month_filter(client, simple_blog_items_with_known_dateti
     count = response.data.get("count")
 
     assert count == 2, "Проверьте фильтрацию по месяцу. Ожидалось только 2 объекта в этом году."
+
+
+def test_blog_item_list_image_absolute_path(client, simple_blog_items_with_known_datetime):
+    response = client.get(BLOG_ITEM_LIST_URL)
+    results = response.data.get("results")
+    blog_item_image = results[0].get("image")
+
+    assert "http://" in blog_item_image, "Убедитесь, что для картинки отдается абсолютный url."

--- a/apps/core/utils.py
+++ b/apps/core/utils.py
@@ -22,10 +22,11 @@ def get_paginated_response(pagination_class, serializer_class, queryset, request
     """Return paginated response. Use it with `list` views based on APIView."""
     paginator = pagination_class()
     page = paginator.paginate_queryset(queryset, request, view=view)
+    context = {"request": request}
 
     if page is not None:
-        serializer = serializer_class(page, many=True)
+        serializer = serializer_class(page, context=context, many=True)
         return paginator.get_paginated_response(serializer.data)
 
-    serializer = serializer_class(queryset, many=True)
+    serializer = serializer_class(queryset, context=context, many=True)
     return Response(data=serializer.data)


### PR DESCRIPTION
1. Утилита `get_pagingated_response` возвращает url с абсолютным путём (передаем контекст)
2. Тест, для blog_item_list что у картинки абсолютный url

По хорошему написать общий тест для утилиты, но чот не сходу не нашел как сделать моковый запрос (не ответ). Поправлю, как разберусь.
