### PR TITLE
Bugfix: masterclass, performance, reading factories

### DIFF
--- a/apps/library/factories/masterclass.py
+++ b/apps/library/factories/masterclass.py
@@ -49,7 +49,7 @@ class MasterClassFactory(factory.django.DjangoModelFactory):
     host_person = factory.RelatedFactory(
         TeamMemberFactory,
         factory_related_name="masterclass",
-        role__slug="host",
+        set_role_with_slug="host",
     )
 
     @factory.post_generation

--- a/apps/library/factories/performance.py
+++ b/apps/library/factories/performance.py
@@ -84,12 +84,12 @@ class PerformanceFactory(factory.django.DjangoModelFactory):
     dramatist_person = factory.RelatedFactory(
         TeamMemberFactory,
         factory_related_name="performance",
-        role__slug="dramatist",
+        set_role_with_slug="dramatist",
     )
     director_person = factory.RelatedFactory(
         TeamMemberFactory,
         factory_related_name="performance",
-        role__slug="director",
+        set_role_with_slug="director",
     )
 
     @factory.post_generation

--- a/apps/library/factories/reading.py
+++ b/apps/library/factories/reading.py
@@ -42,12 +42,12 @@ class ReadingFactory(factory.django.DjangoModelFactory):
     dramatist_person = factory.RelatedFactory(
         TeamMemberFactory,
         factory_related_name="reading",
-        role__slug="dramatist",
+        set_role_with_slug="dramatist",
     )
     director_person = factory.RelatedFactory(
         TeamMemberFactory,
         factory_related_name="reading",
-        role__slug="director",
+        set_role_with_slug="director",
     )
 
     @factory.post_generation

--- a/apps/library/factories/team_member.py
+++ b/apps/library/factories/team_member.py
@@ -15,9 +15,15 @@ class TeamMemberFactory(factory.django.DjangoModelFactory):
     The factory will fail if non of `performance` or `reading` or `masterclass`
     is set during call.
 
-    You should create at least one Person and Role before use this factory.
-    This factory can be used only inside Reading, Performance
-    or Master Class factories.
+    Default behavior: the factory sets random but permitted roles based on the
+    type of related objects: masterclass, reading, or performance. It's model
+    logic: team_member could be connected to only one of these objects.
+
+    Parameters:
+    1. `set_role_with_slug=<str>`: if the parameter is set the factory will use
+    that role instead of a random one. Please use with caution: with that
+    parameter, you can set any of existed roles, even with an incorrect role
+    type.
     """
 
     class Meta:
@@ -50,3 +56,10 @@ class TeamMemberFactory(factory.django.DjangoModelFactory):
         allowable_roles = Role.objects.filter(types__in=role_type)
         allowable_random_role = allowable_roles.order_by("?").first()
         return allowable_random_role
+
+    @factory.post_generation
+    def set_role_with_slug(self, create, role_slug, **kwargs):
+        """Override the `role` attribute with the role that matches `role_slug`."""
+        if create and role_slug:
+            role = Role.objects.get(slug=role_slug)
+            self.role = role

--- a/apps/main/tests/conftest.py
+++ b/apps/main/tests/conftest.py
@@ -111,6 +111,6 @@ def performance(plays, persons):
 
 
 @pytest.fixture
-def events(freezer, reading, performance, master_class):
+def events_pinned_on_main(freezer, reading, performance, master_class):
     freezer.move_to("2021-05-20 15:42")
-    return EventFactory.create_batch(4, date_time_in_three_hours=True)
+    return EventFactory.create_batch(4, date_time_in_three_hours=True, pinned_on_main=True)

--- a/apps/main/tests/test_urls.py
+++ b/apps/main/tests/test_urls.py
@@ -6,7 +6,16 @@ pytestmark = pytest.mark.django_db
 
 
 class TestMainAPIUrls:
-    def test_main_urls(self, client, news_items_with_content, blog_items_with_content, banners, plays, places, events):
+    def test_main_urls(
+        self,
+        client,
+        news_items_with_content,
+        blog_items_with_content,
+        banners,
+        plays,
+        places,
+        events_pinned_on_main,
+    ):
         """Checks status code for main url."""
         response = client.get(MAIN_URL)
         assert response.status_code == 200, f"Проверьте, что при GET запросе " f"{MAIN_URL} возвращается статус 200"

--- a/apps/main/tests/test_views.py
+++ b/apps/main/tests/test_views.py
@@ -175,7 +175,7 @@ class TestMainAPIViews:
         self,
         client,
         news_items_with_content,
-        events,
+        events_pinned_on_main,
         banners,
         places,
     ):
@@ -191,7 +191,7 @@ class TestMainAPIViews:
         self,
         client,
         news_items_with_content,
-        events,
+        events_pinned_on_main,
     ):
         """Checks data["afisha"]["items"]["event_body"] in response."""
         fields = ["id", "name", "description", "team", "project_title"]
@@ -201,7 +201,7 @@ class TestMainAPIViews:
                 field in response.data["afisha"]["items"][0]["event_body"]
             ), f"Проверьте, что при GET запросе {MAIN_URL} data[afisha][items][0][event_body] содержит {field}"
 
-    def test_get_main_afisha_items_event_body_team_fields(self, client, news_items_with_content, events):
+    def test_get_main_afisha_items_event_body_team_fields(self, client, news_items_with_content, events_pinned_on_main):
         """Get `team` in response (response -> afisha -> items -> event_body -> team) and look for expected fields."""
         expected_fields_set = {
             "name",
@@ -229,7 +229,7 @@ class TestMainAPIViews:
         client,
         news_items_with_content,
         blog_items_with_content,
-        events,
+        events_pinned_on_main,
     ):
         """Checks that count afisha items in response matches count in db."""
         today = timezone.now()


### PR DESCRIPTION
Поправил ошибку в фабриках, которую допустил пока их переписывал. Сейчас нельзя использовать `role__slug`, так как не используются вложенные фабрики.

Добавил новый метод в фабрику TeamMember + убедился, что 50 итераций тестов не падают (раньше на таком количестве падали 2-3 раза).

Поправил ошибку теста событий на главное: создавали события без 100% отметки, что запинены на главной -> тесты могли упасть.