### PR TITLE
bugfix(perms): Translate the default permissions

### DIFF
--- a/apps/users/admin.py
+++ b/apps/users/admin.py
@@ -1,11 +1,36 @@
 from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
+from django.contrib.auth.models import Permission
+from django.utils import six
 
 from .forms import GroupAdminForm, UserAdminForm
 from .models import ProxyGroup
 
 User = get_user_model()
+
+
+def permissions_new_unicode(self):
+    class_name = six.text_type(self.content_type)
+    permissions_name = six.text_type(self.name)
+    if "Can delete log entry" in permissions_name:
+        permissions_name = permissions_name.replace("Can delete log entry", "Может удалить запись в журнале")
+    elif "Can change log entry" in permissions_name:
+        permissions_name = permissions_name.replace("Can change log entry", "Может изменять запись в журнале")
+    elif "Can add log entry" in permissions_name:
+        permissions_name = permissions_name.replace("Can add log entry", "Может добавлять запись в журнале")
+    elif "Can view log entry" in permissions_name:
+        permissions_name = permissions_name.replace("Can view log entry", "Может просматривать запись в журнале")
+    elif "Can delete" in permissions_name:
+        permissions_name = permissions_name.replace("Can delete", "Может удалять")
+    elif "Can add" in permissions_name:
+        permissions_name = permissions_name.replace("Can add", "Может добавлять")
+    elif "Can change" in permissions_name:
+        permissions_name = permissions_name.replace("Can change", "Может изменять")
+    elif "Can view" in permissions_name:
+        permissions_name = permissions_name.replace("Can view", "Может просматривать")
+
+    return "%s - %s" % (class_name.title(), permissions_name)
 
 
 @admin.register(User)
@@ -43,10 +68,10 @@ class UserAdmin(DjangoUserAdmin):
 
 
 class GroupAdmin(admin.ModelAdmin):
-
     form = GroupAdminForm
     list_display = ["name"]
     filter_horizontal = ("permissions",)
 
 
 admin.site.register(ProxyGroup, GroupAdmin)
+Permission.__str__ = permissions_new_unicode


### PR DESCRIPTION
Задача: https://www.notion.so/5bf777119b034c6f8482e401d9da0242
Реализован выбранный вариант 2 из [этого](https://stackoverflow.com/questions/23419919/how-to-change-name-by-default-of-permission-in-django) источника.
