### PR TITLE
Очистка неиспользуемых docker контейнеров, образов, сетей

### DIFF
--- a/.github/workflows/backend_deploy_prod.yaml
+++ b/.github/workflows/backend_deploy_prod.yaml
@@ -160,6 +160,9 @@ jobs:
 
             echo YNDX_DISK=${{ secrets.YNDX_DISK }} >> .env-prod
 
+            # Очистка неиспользуемых контейнеров, образов, сетей
+            docker system prune --force
+
             docker network create prod_db_network || true
             docker network create prod_swag_network || true
 

--- a/.github/workflows/backend_deploy_stage.yaml
+++ b/.github/workflows/backend_deploy_stage.yaml
@@ -160,6 +160,9 @@ jobs:
 
             echo YNDX_DISK=${{ secrets.YNDX_DISK }} >> .env-stage
 
+            # Очистка неиспользуемых контейнеров, образов, сетей
+            docker system prune --force
+
             # Создание сети вынесено отдельно для возможности независимо перезапускать контейнеры (через external networks)
             docker network create stage_db_network || true
             docker network create stage_swag_network || true

--- a/.github/workflows/backend_deploy_test.yaml
+++ b/.github/workflows/backend_deploy_test.yaml
@@ -162,6 +162,8 @@ jobs:
             systemctl stop lubimovka-frontend.service
             systemctl stop lubimovka-backend.service
             docker-compose -f lubimovka_backend_test_deploy.yml --env-file /LUBIMOVKA/test/.github_vars down -v
+            # Очистка неиспользуемых контейнеров, образов, сетей
+            docker system prune --force
 
             # Создание сети вынесено отдельно для возможности независимо перезапускать контейнеры (через external networks)
             docker network create test_db_network || true


### PR DESCRIPTION
Добавил "docker system prune --force" перед запуском службы, а не после, так как служба стартует не сразу и перед запуском останавливает старый контейнер, затем скачивает docker image (иногда не быстро скачивает), затем запускает новый контейнер и если в этот момент запустить очистку, то может удалить лишнее (так как контейнер может быть еще не запущен).

Когда создаёте PR, убедитесь, что:

- [ ] вы проверили обновления в [брифе](https://www.notion.so/00f5d5a6d39e426fa1ea7ab69b694f07)
- [ ] синхронизировали изменения кода с [ER-диаграммой базы данных](https://drive.google.com/file/d/1RCIPaEgaLUSqek3znd38VPCKSzOlmJFy/view) связей моделей
- [ ] убедились, что модель OpenAPI проверена (в Swagger отображаются изменения)
- [ ] тесты все пройдены и нет конфликтов
- [ ] созданы необходимые миграции

Когда ваш PR смержен:

- [ ] если у вас были изменения в API, сообщите об этом команде Фронта, им это важно знать!
