### PR TITLE
Bugfix/cicd

### DIFF
--- a/infra_deploy/prod/lubimovka-backend.service
+++ b/infra_deploy/prod/lubimovka-backend.service
@@ -6,6 +6,7 @@ After=docker.service
 [Service]
 Restart=always
 RestartSec=5
+TimeoutStartSec=600
 User=root
 
 WorkingDirectory=/LUBIMOVKA/prod/

--- a/infra_deploy/prod/lubimovka-backend.service
+++ b/infra_deploy/prod/lubimovka-backend.service
@@ -6,7 +6,7 @@ After=docker.service
 [Service]
 Restart=always
 RestartSec=5
-TimeoutStartSec=600
+TimeoutStartSec=1200
 User=root
 
 WorkingDirectory=/LUBIMOVKA/prod/

--- a/infra_deploy/prod/lubimovka-frontend.service
+++ b/infra_deploy/prod/lubimovka-frontend.service
@@ -6,6 +6,7 @@ After=docker.service
 [Service]
 Restart=always
 RestartSec=5
+TimeoutStartSec=600
 User=root
 
 WorkingDirectory=/LUBIMOVKA/prod/

--- a/infra_deploy/prod/lubimovka-frontend.service
+++ b/infra_deploy/prod/lubimovka-frontend.service
@@ -6,7 +6,7 @@ After=docker.service
 [Service]
 Restart=always
 RestartSec=5
-TimeoutStartSec=600
+TimeoutStartSec=1200
 User=root
 
 WorkingDirectory=/LUBIMOVKA/prod/

--- a/infra_deploy/stage/lubimovka-backend.service
+++ b/infra_deploy/stage/lubimovka-backend.service
@@ -6,7 +6,7 @@ After=docker.service
 [Service]
 Restart=always
 RestartSec=5
-TimeoutStartSec=600
+TimeoutStartSec=1200
 User=root
 
 WorkingDirectory=/LUBIMOVKA/stage/

--- a/infra_deploy/stage/lubimovka-backend.service
+++ b/infra_deploy/stage/lubimovka-backend.service
@@ -6,6 +6,7 @@ After=docker.service
 [Service]
 Restart=always
 RestartSec=5
+TimeoutStartSec=600
 User=root
 
 WorkingDirectory=/LUBIMOVKA/stage/

--- a/infra_deploy/stage/lubimovka-frontend.service
+++ b/infra_deploy/stage/lubimovka-frontend.service
@@ -6,7 +6,7 @@ After=docker.service
 [Service]
 Restart=always
 RestartSec=5
-TimeoutStartSec=600
+TimeoutStartSec=1200
 User=root
 
 WorkingDirectory=/LUBIMOVKA/stage/

--- a/infra_deploy/stage/lubimovka-frontend.service
+++ b/infra_deploy/stage/lubimovka-frontend.service
@@ -6,6 +6,7 @@ After=docker.service
 [Service]
 Restart=always
 RestartSec=5
+TimeoutStartSec=600
 User=root
 
 WorkingDirectory=/LUBIMOVKA/stage/

--- a/infra_deploy/test/lubimovka-backend.service
+++ b/infra_deploy/test/lubimovka-backend.service
@@ -6,7 +6,7 @@ After=docker.service
 [Service]
 Restart=always
 RestartSec=5
-TimeoutStartSec=600
+TimeoutStartSec=1200
 User=root
 
 WorkingDirectory=/LUBIMOVKA/test/

--- a/infra_deploy/test/lubimovka-backend.service
+++ b/infra_deploy/test/lubimovka-backend.service
@@ -6,6 +6,7 @@ After=docker.service
 [Service]
 Restart=always
 RestartSec=5
+TimeoutStartSec=600
 User=root
 
 WorkingDirectory=/LUBIMOVKA/test/

--- a/infra_deploy/test/lubimovka-frontend.service
+++ b/infra_deploy/test/lubimovka-frontend.service
@@ -6,7 +6,7 @@ After=docker.service
 [Service]
 Restart=always
 RestartSec=5
-TimeoutStartSec=600
+TimeoutStartSec=1200
 User=root
 
 WorkingDirectory=/LUBIMOVKA/test/

--- a/infra_deploy/test/lubimovka-frontend.service
+++ b/infra_deploy/test/lubimovka-frontend.service
@@ -6,6 +6,7 @@ After=docker.service
 [Service]
 Restart=always
 RestartSec=5
+TimeoutStartSec=600
 User=root
 
 WorkingDirectory=/LUBIMOVKA/test/


### PR DESCRIPTION
Решение проблемы запуска приложения при низкой скорости скачивания docker image. Таймаут у systemd по умолчанию 1,5 минуты, и часто бывает, что образы загружаются из ghcr.io медленно (более 10 минут), что приводило к рестарту службы и скачивание не завершалось до конца. Служба не могла запуститься.

Позже рассмотрю возможность использования slim образов для уменьшения их размера.
lubimovka_backend    1.23GB
lubimovka_frontend   420MB



Когда создаёте PR, убедитесь, что:

- [ ] вы проверили обновления в [брифе](https://www.notion.so/00f5d5a6d39e426fa1ea7ab69b694f07)
- [ ] синхронизировали изменения кода с [ER-диаграммой базы данных](https://drive.google.com/file/d/1RCIPaEgaLUSqek3znd38VPCKSzOlmJFy/view) связей моделей
- [ ] убедились, что модель OpenAPI проверена (в Swagger отображаются изменения)
- [ ] тесты все пройдены и нет конфликтов
- [ ] созданы необходимые миграции

Когда ваш PR смержен:

- [ ] если у вас были изменения в API, сообщите об этом команде Фронта, им это важно знать!
