### PR TITLE
PlaysBlock now has correct OpenAPI schema

### DIFF
--- a/apps/articles/tests/blog_items/tests_views/test_blog_item_detail.py
+++ b/apps/articles/tests/blog_items/tests_views/test_blog_item_detail.py
@@ -73,7 +73,7 @@ def test_blog_item_detail_first_level_attributes(client, first_level_field, comp
 
 
 def test_blog_item_detail_contents_and_order(client, complex_blog_item):
-    """Get `contents` array and look for created `ContentModule` attributes. Order is important."""
+    """Get `contents` array and look for created `ContentModule` attributes. Order is matter."""
     response = client.get(BLOG_ITEM_DETAIL_URL)
     response_contents = response.data.get("contents")
     expected_content_in_order = (
@@ -86,8 +86,32 @@ def test_blog_item_detail_contents_and_order(client, complex_blog_item):
         "personsblock",
     )
 
-    assert len(response_contents) == 7, "В созданном объекте должно быть 7 блоков контентаю"
+    assert len(response_contents) == 7, "В созданном объекте должно быть 7 блоков контента."
 
     for order in range(7):
         content_type = response_contents[order].get("content_type")
         assert content_type == expected_content_in_order[order], "Проверьте порядок следования контента."
+
+
+def test_blog_item_detail_plays_block_content_fields(client, complex_blog_item):
+    """Get `contents` -> `playsblock` item and look for expected fields."""
+    response = client.get(BLOG_ITEM_DETAIL_URL)
+    response_contents = response.data.get("contents")
+    playsblock_content = response_contents[4]
+    playsblock_content_item = playsblock_content.get("content_item")
+
+    assert playsblock_content_item.get("title"), "У блока с пьесами должен быть заголовок."
+    assert playsblock_content_item.get("items"), "У блока с пьесами должен быть массив элементов (пьес)."
+    assert len(playsblock_content_item.get("items")) == 3, "Ожидалось 3 пьесы в блоке с пьесами."
+
+    first_play = playsblock_content_item.get("items")[0]
+    expected_play_fields_in_order = (
+        "id",
+        "name",
+        "authors",
+        "city",
+        "year",
+    )
+
+    for order, field in enumerate(first_play):
+        assert field == expected_play_fields_in_order[order], "Проверьте fields и их порядок в элементе пьесы"

--- a/apps/content_pages/serializers/__init__.py
+++ b/apps/content_pages/serializers/__init__.py
@@ -2,6 +2,7 @@ from .content_items import (
     ExtendedPersonSerializer,
     LinkSerializer,
     OrderedImageSerializer,
+    OrderedPlaySerializer,
     OrderedVideoSerializer,
     PreambleSerializer,
     QuoteSerializer,

--- a/apps/content_pages/serializers/content_blocks.py
+++ b/apps/content_pages/serializers/content_blocks.py
@@ -1,31 +1,22 @@
 from rest_framework import serializers
 
 from apps.afisha.models import Event
-from apps.afisha.serializers import AfishaEventSerializer
 from apps.content_pages.models import EventsBlock, ImagesBlock, PersonsBlock, PlaysBlock, VideosBlock
-from apps.content_pages.serializers import ExtendedPersonSerializer, OrderedImageSerializer, OrderedVideoSerializer
-from apps.library.serializers import PlaySerializer as LibraryPlaySerializer
+from apps.content_pages.serializers import (
+    ExtendedPersonSerializer,
+    OrderedImageSerializer,
+    OrderedPlaySerializer,
+    OrderedVideoSerializer,
+)
 from apps.library.serializers.performance import EventPerformanceSerializer
 
 
-class SlugRelatedSerializerField(serializers.SlugRelatedField):
-    """The field works exactly as SlugRelatedField but returns full object serialized with 'serializer_class'."""
-
-    def __init__(self, serializer_class=None, **kwargs):
-        assert serializer_class is not None, "The 'serializer_class' argument is required."
-        self.serializer_class = serializer_class
-        super().__init__(**kwargs)
-
-    def to_representation(self, obj):
-        item = getattr(obj, self.slug_field)
-        serializer = self.serializer_class(item, context=self.context)
-        return serializer.data
-
-
-class EventInBlockSerializer(AfishaEventSerializer):
+class EventInBlockSerializer(serializers.ModelSerializer):
     """Returns Performance in EventsBlock."""
 
-    event_body = EventPerformanceSerializer(source="common_event.target_model")
+    event_body = EventPerformanceSerializer(
+        source="common_event.target_model",
+    )
 
     class Meta:
         model = Event
@@ -42,7 +33,6 @@ class EventInBlockSerializer(AfishaEventSerializer):
 class EventsBlockSerializer(serializers.ModelSerializer):
     items = EventInBlockSerializer(
         many=True,
-        read_only=True,
     )
 
     class Meta:
@@ -56,7 +46,6 @@ class EventsBlockSerializer(serializers.ModelSerializer):
 class VideosBlockSerializer(serializers.ModelSerializer):
     items = OrderedVideoSerializer(
         many=True,
-        read_only=True,
         source="ordered_videos",
     )
 
@@ -71,7 +60,6 @@ class VideosBlockSerializer(serializers.ModelSerializer):
 class ImagesBlockSerializer(serializers.ModelSerializer):
     items = OrderedImageSerializer(
         many=True,
-        read_only=True,
         source="ordered_images",
     )
 
@@ -87,7 +75,6 @@ class PersonsBlockSerializer(serializers.ModelSerializer):
     items = ExtendedPersonSerializer(
         source="extended_persons",
         many=True,
-        read_only=True,
     )
 
     class Meta:
@@ -99,12 +86,9 @@ class PersonsBlockSerializer(serializers.ModelSerializer):
 
 
 class PlaysBlockSerializer(serializers.ModelSerializer):
-    items = SlugRelatedSerializerField(
-        many=True,
-        read_only=True,
+    items = OrderedPlaySerializer(
         source="ordered_plays",
-        slug_field="item",
-        serializer_class=LibraryPlaySerializer,
+        many=True,
     )
 
     class Meta:

--- a/apps/content_pages/serializers/content_items.py
+++ b/apps/content_pages/serializers/content_items.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 
 from apps.content_pages.models import Link, OrderedImage, OrderedVideo, Preamble, Quote, Text, Title
 from apps.core.serializers import PersonRoleSerializer
+from apps.library.serializers import AuthorForPlaySerializer as LibraryPlayAuthorSerializer
 
 
 class ExtendedPersonSerializer(serializers.Serializer):
@@ -83,6 +84,34 @@ class OrderedImageSerializer(serializers.ModelSerializer):
             "title",
             "image",
         )
+
+
+class OrderedPlaySerializer(serializers.Serializer):
+    id = serializers.IntegerField(
+        source="item.id",
+        label="ID",
+        read_only=True,
+    )
+    name = serializers.CharField(
+        source="item.name",
+        label="Название пьесы",
+        max_length=70,
+    )
+    authors = LibraryPlayAuthorSerializer(
+        source="item.authors",
+        many=True,
+    )
+    city = serializers.CharField(
+        source="item.city",
+        label="Город",
+        max_length=200,
+        required=False,
+    )
+    year = serializers.IntegerField(
+        source="item.year",
+        required=False,
+        label="Год написания пьесы",
+    )
 
 
 class OrderedVideoSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
OpenAPI схема для для PlaysBlock (блок конструктора).
Добавил тест для блога  — смотрим наличие полей и их порядок в элементе пьесы у блога.

<img width="867" alt="screenshot_2022-04-03_at_16 31 00@2x" src="https://user-images.githubusercontent.com/70921439/161430497-937a591d-b969-4fe3-9395-9f2efced5dda.png">

