### PR TITLE
bugfix(permissions) Remove site/session permissions

### DIFF
--- a/apps/core/management/commands/set_perms.py
+++ b/apps/core/management/commands/set_perms.py
@@ -141,6 +141,12 @@ class Command(BaseCommand):
             observer, created = Group.objects.get_or_create(name="observer")
             observer.permissions.set(observer_permissions)
 
+            # Удалить разрешения для приложений Sites и Sessions
+            deleted_permissions = Permission.objects.filter(
+                Q(codename__icontains="_site") | Q(codename__icontains="_session")
+            )
+            deleted_permissions.delete()
+
             self.stdout.write(self.style.SUCCESS("Права для пользователей успешно установлены."))
         except CommandError:
             self.stdout.write(self.style.ERROR("Ошибка установки прав."))


### PR DESCRIPTION
Тикет вашего PR (если есть):
[  тикет](https://www.notion.so/5bf777119b034c6f8482e401d9da0242)

В этом PR **удаляются** разрешения по умолчанию для приложений  Sites. и Sessions.
Для удаление запускается скрипт `python manage.py set_perms `

В отличии от этого [PR](https://github.com/Studio-Yandex-Practicum/Lubimovka_backend/pull/341) разрешения **удаляются а не скрываются.** И это может вызвать некоторые проблемы-нужно тестировать.