### PR TITLE
partners API: фильтрация по списку партнеров + тесты для этого

### DIFF
--- a/apps/info/filters.py
+++ b/apps/info/filters.py
@@ -1,11 +1,28 @@
+import django_filters
 from django.contrib import admin
 from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
-from django_filters import FilterSet, filters
+
+from apps.info.models import Partner
 
 
-class YearFestivalFilterSet(FilterSet):
-    year = filters.NumberFilter(field_name="festival__year")
+class CharInFilter(django_filters.BaseInFilter, django_filters.CharFilter):
+    pass
+
+
+class YearFestivalFilterSet(django_filters.FilterSet):
+    year = django_filters.NumberFilter(field_name="festival__year")
+
+
+class PartnerFilterSet(django_filters.FilterSet):
+    types = CharInFilter(field_name="type", lookup_expr="in")
+
+    class Meta:
+        model = Partner
+        fields = (
+            "types",
+            "in_footer_partner",
+        )
 
 
 class HasReviewAdminFilter(admin.SimpleListFilter):

--- a/apps/info/models/people.py
+++ b/apps/info/models/people.py
@@ -44,9 +44,8 @@ class Partner(BaseModel):
 
     def save(self, *args, **kwargs):
         this = Partner.objects.filter(id=self.id).first()
-        if this:
-            if this.image != self.image:
-                this.image.delete(save=False)
+        if this and this.image != self.image:
+            this.image.delete(save=False)
         super().save(*args, **kwargs)
 
     def __str__(self):

--- a/apps/info/selectors/__init__.py
+++ b/apps/info/selectors/__init__.py
@@ -1,0 +1,1 @@
+from .partners import partner_list

--- a/apps/info/selectors/partners.py
+++ b/apps/info/selectors/partners.py
@@ -1,0 +1,12 @@
+from django.db.models import QuerySet
+
+from apps.info.filters import PartnerFilterSet
+from apps.info.models import Partner
+
+
+def partner_list(filters: dict[str, str] = None) -> QuerySet:
+    """Return filtered queryset of `Partner`."""
+    filters = filters or {}
+    qs = Partner.objects.all()
+    filtered_qs = PartnerFilterSet(data=filters, queryset=qs).qs
+    return filtered_qs

--- a/apps/info/serializers/__init__.py
+++ b/apps/info/serializers/__init__.py
@@ -1,7 +1,6 @@
 from .contacts import ContactsSerializer
 from .festival import FestivalSerializer, YearsSerializer
 from .festivalteams import FestivalTeamsSerializer
-from .partners import PartnerSerializer
 from .press_release import PressReleaseSerializer
 from .selectors import SelectorsSerializer
 from .settings import SettingsSerializer
@@ -10,7 +9,6 @@ from .volunteers import VolunteersSerializer
 
 __all__ = (
     PressReleaseSerializer,
-    PartnerSerializer,
     SponsorSerializer,
     FestivalTeamsSerializer,
     VolunteersSerializer,

--- a/apps/info/serializers/partners.py
+++ b/apps/info/serializers/partners.py
@@ -1,9 +1,0 @@
-from rest_framework import serializers
-
-from apps.info.models import Partner
-
-
-class PartnerSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Partner
-        exclude = ("created", "modified")

--- a/apps/info/tests/conftest.py
+++ b/apps/info/tests/conftest.py
@@ -1,29 +1,19 @@
 import pytest
 from django.conf import settings
-from django.urls import reverse
+from rest_framework.test import APIClient
 
 from apps.core.factories import ImageFactory, PersonFactory
-from apps.info.factories import (
-    FestivalFactory,
-    FestivalTeamFactory,
-    PartnerFactory,
-    SelectorFactory,
-    SponsorFactory,
-    VolunteerFactory,
-)
-
-FESTIVAL_URL_NAME = "festivals"
-FESTIVAL_YEARS_URL = reverse("festivals-years")
-TEAMS_URL = reverse("festival-teams")
-TEAMS_URL_FILTER = TEAMS_URL + "?team="
-SPONSORS_URL = reverse("sponsors")
-VOLUNTEERS_URL = reverse("volunteers")
-PARTNERS_URL = reverse("partners")
+from apps.info.factories import FestivalFactory, FestivalTeamFactory, SelectorFactory, SponsorFactory, VolunteerFactory
 
 
 @pytest.fixture(autouse=True)
 def set_media_temp_folder(tmpdir):
     settings.MEDIA_ROOT = tmpdir.mkdir("media")
+
+
+@pytest.fixture(autouse=True)
+def client():
+    return APIClient(format="json")
 
 
 @pytest.fixture
@@ -62,35 +52,25 @@ def images():
 
 
 @pytest.fixture
-def festival(images):
-    return FestivalFactory()
+def festival_2020(images):
+    return FestivalFactory(year=2020)
 
 
 @pytest.fixture
-def volunteer(persons_with_image_email_city, festival):
+def volunteer(persons_with_image_email_city, festival_2020):
     return VolunteerFactory()
 
 
 @pytest.fixture
-def volunteers(persons_with_image_email_city, festival):
+def volunteers(persons_with_image_email_city, festival_2020):
     return VolunteerFactory.create_batch(5)
 
 
 @pytest.fixture
-def selector(persons_with_image_email_city, festival):
+def selector(persons_with_image_email_city, festival_2020):
     return SelectorFactory()
 
 
 @pytest.fixture
-def selectors(persons_with_image_email_city, festival):
+def selectors(persons_with_image_email_city, festival_2020):
     return SelectorFactory.create_batch(5)
-
-
-@pytest.fixture
-def partner():
-    return PartnerFactory()
-
-
-@pytest.fixture
-def partners():
-    return PartnerFactory.create_batch(5)

--- a/apps/info/tests/test_urls.py
+++ b/apps/info/tests/test_urls.py
@@ -1,43 +1,27 @@
 import pytest
-from django.urls import reverse
-
-from apps.info.tests.conftest import (
-    FESTIVAL_URL_NAME,
-    FESTIVAL_YEARS_URL,
-    PARTNERS_URL,
-    SPONSORS_URL,
-    TEAMS_URL,
-    VOLUNTEERS_URL,
-)
+from rest_framework import status
 
 pytestmark = pytest.mark.django_db
 
 
-class TestFestivalAPIUrls:
-    def test_festival_urls(self, client, festival):
-        """Checks status code for festival url."""
-        urls = (
-            FESTIVAL_YEARS_URL,
-            reverse(FESTIVAL_URL_NAME, kwargs={"year": festival.year}),
-        )
-        for url in urls:
-            response = client.get(url)
-            assert response.status_code == 200, f"Проверьте, что при GET запросе {url} возвращается статус 200"
+@pytest.mark.parametrize(
+    "url",
+    (
+        "/api/v1/info/partners/",
+        "/api/v1/info/festivals/years/",
+        "/api/v1/info/about-festival/selectors/",
+        "/api/v1/info/about-festival/sponsors/",
+        "/api/v1/info/about-festival/team/",
+        "/api/v1/info/about-festival/volunteers/",
+    ),
+)
+def test_info_url_smoke(client, url):
+    """Smoke test. Status code check only."""
+    response = client.get(url)
+    assert response.status_code == status.HTTP_200_OK
 
 
-class TestAboutFestivalAPIUrls:
-    """Checks status code for about festival urls."""
-
-    @pytest.mark.parametrize("url", (TEAMS_URL, SPONSORS_URL, VOLUNTEERS_URL))
-    def test_about_festival_urls(self, client, url):
-        response = client.get(url)
-        assert response.status_code == 200, f"Проверьте, что при GET запросе {url} возвращается статус 200"
-
-
-class TestPartnersAPIUrls:
-    """Checks status code for partners url."""
-
-    def test_partners_urls(self, client):
-        url = PARTNERS_URL
-        response = client.get(url)
-        assert response.status_code == 200, f"Проверьте, что при GET запросе {url} возвращается статус 200"
+def test_info_url_festival_detail_smoke(client, festival_2020):
+    """Smoke test for exact festival."""
+    response = client.get("/api/v1/info/festivals/2020/")
+    assert response.status_code == status.HTTP_200_OK

--- a/apps/info/tests/tests_views/test_about_festivals.py
+++ b/apps/info/tests/tests_views/test_about_festivals.py
@@ -1,90 +1,22 @@
-from datetime import datetime
-
 import pytest
 from django.urls import reverse
 
 from apps.info.models import FestivalTeamMember
-from apps.info.tests.conftest import (
-    FESTIVAL_URL_NAME,
-    FESTIVAL_YEARS_URL,
-    PARTNERS_URL,
-    SPONSORS_URL,
-    TEAMS_URL,
-    TEAMS_URL_FILTER,
-    VOLUNTEERS_URL,
-)
 
 pytestmark = pytest.mark.django_db
 
-ABOUT_FESTIVAL_URLS_AND_FIXTURES = [
+
+TEAMS_URL = reverse("festival-teams")
+TEAMS_URL_FILTER = TEAMS_URL + "?team="
+SPONSORS_URL = reverse("sponsors")
+VOLUNTEERS_URL = reverse("volunteers")
+
+
+ABOUT_FESTIVAL_URLS_AND_FIXTURES = (
     (TEAMS_URL, pytest.lazy_fixture("festival_team")),
     (SPONSORS_URL, pytest.lazy_fixture("sponsor")),
     (VOLUNTEERS_URL, pytest.lazy_fixture("volunteer")),
-]
-
-
-class TestFestivalAPIViews:
-    def test_get_festival_fields(self, client, festival):
-        """Checks festival field in response."""
-        url = reverse(FESTIVAL_URL_NAME, kwargs={"year": festival.year})
-        response = client.get(url)
-        data = response.json()
-        for field in (
-            "description",
-            "year",
-            "plays_count",
-            "selected_plays_count",
-            "selectors_count",
-            "volunteers_count",
-            "events_count",
-            "cities_count",
-            "blog_entries",
-            "video_link",
-        ):
-            festival_field_in_response = data.get(field)
-            festival_field_in_db = getattr(festival, field)
-            assert (
-                festival_field_in_response == festival_field_in_db
-            ), f"Проверьте, что при GET запросе {url} возвращаются данные объекта. Значение {field} неправильное"
-        for field in (
-            "start_date",
-            "end_date",
-        ):
-            date = data.get(field)
-            festival_field_in_response = datetime.strptime(date, "%Y-%m-%d").date()
-            festival_field_in_db = getattr(festival, field)
-            assert (
-                festival_field_in_response == festival_field_in_db
-            ), f"Проверьте, что при GET запросе {url} возвращаются данные объекта. Значение {field} неправильное"
-
-    @pytest.mark.parametrize(
-        "field",
-        (
-            "volunteers",
-            "images",
-        ),
-    )
-    def test_get_volunteers_and_images_from_festival(self, client, festival, field):
-        """Checks volunteers and images count in festival."""
-        url = reverse(FESTIVAL_URL_NAME, kwargs={"year": festival.year})
-        response = client.get(url)
-        data = response.json()
-        objects_count_in_response = len(data.get(field))
-        objects_count_in_db = getattr(festival, field).all().count()
-        assert (
-            objects_count_in_response == objects_count_in_db
-        ), f"Проверьте, что при GET запросе {url} возвращаются данные объекта. Значение {field} неправильное"
-
-    def test_get_festival_years(self, client, festival):
-        """Check getting festival years."""
-        url = FESTIVAL_YEARS_URL
-        response = client.get(url)
-        data = response.json()
-        year_in_db = getattr(festival, "year")
-        years_in_response = data.get("years")
-        assert (
-            year_in_db in years_in_response
-        ), f"Проверьте, что при GET запросе {url} возвращается список годов фестивалей"
+)
 
 
 class TestAboutFestivalAPIViews:
@@ -190,41 +122,6 @@ class TestAboutFestivalAPIViews:
         data = response.json()
         image_url_in_response = data[0].get("person").get("image")
         image_url_in_db = object.person.image.url
-        assert image_url_in_response.endswith(
-            image_url_in_db
-        ), f"Проверьте, что при GET запросе {url} возвращаются данные объекта. Значение 'image' неправильное"
-
-
-class TestPartnersAPIViews:
-    def test_partners_count_in_response_matches_count_in_db(self, client, partners):
-        """Checks that count partners in response matches count in db."""
-        url = PARTNERS_URL
-        response = client.get(url)
-        objects_count_in_response = len(response.json())
-        objects_count_in_db = len(partners)
-        assert (
-            objects_count_in_db == objects_count_in_response
-        ), f"Проверьте, что при GET запросе {url} возвращаются все объекты"
-
-    def test_get_partners_fields(self, client, partner):
-        """Checks partners field in response."""
-        url = PARTNERS_URL
-        response = client.get(url)
-        data = response.json()
-        for field in ("id", "name", "type", "url"):
-            team_field_in_response = data[0].get(field)
-            team_field_in_db = getattr(partner, field)
-            assert (
-                team_field_in_response == team_field_in_db
-            ), f"Проверьте, что при GET запросе {url} возвращаются данные объекта. Значение {field} неправильное"
-
-    def test_get_image_for_person(self, client, partner):
-        """Checks partners image field in response."""
-        url = PARTNERS_URL
-        response = client.get(url)
-        data = response.json()
-        image_url_in_response = data[0].get("image")
-        image_url_in_db = partner.image.url
         assert image_url_in_response.endswith(
             image_url_in_db
         ), f"Проверьте, что при GET запросе {url} возвращаются данные объекта. Значение 'image' неправильное"

--- a/apps/info/tests/tests_views/test_festivals.py
+++ b/apps/info/tests/tests_views/test_festivals.py
@@ -1,0 +1,73 @@
+from datetime import datetime
+
+import pytest
+from django.urls import reverse
+
+FESTIVAL_URL_NAME = "festivals"
+FESTIVAL_YEARS_URL = reverse("festivals-years")
+
+pytestmark = pytest.mark.django_db
+
+
+class TestFestivalAPIViews:
+    def test_get_festival_fields(self, client, festival_2020):
+        """Checks festival field in response."""
+        url = reverse(FESTIVAL_URL_NAME, kwargs={"year": festival_2020.year})
+        response = client.get(url)
+        data = response.json()
+        for field in (
+            "description",
+            "year",
+            "plays_count",
+            "selected_plays_count",
+            "selectors_count",
+            "volunteers_count",
+            "events_count",
+            "cities_count",
+            "blog_entries",
+            "video_link",
+        ):
+            festival_field_in_response = data.get(field)
+            festival_field_in_db = getattr(festival_2020, field)
+            assert (
+                festival_field_in_response == festival_field_in_db
+            ), f"Проверьте, что при GET запросе {url} возвращаются данные объекта. Значение {field} неправильное"
+        for field in (
+            "start_date",
+            "end_date",
+        ):
+            date = data.get(field)
+            festival_field_in_response = datetime.strptime(date, "%Y-%m-%d").date()
+            festival_field_in_db = getattr(festival_2020, field)
+            assert (
+                festival_field_in_response == festival_field_in_db
+            ), f"Проверьте, что при GET запросе {url} возвращаются данные объекта. Значение {field} неправильное"
+
+    @pytest.mark.parametrize(
+        "field",
+        (
+            "volunteers",
+            "images",
+        ),
+    )
+    def test_get_volunteers_and_images_from_festival(self, client, festival_2020, field):
+        """Checks volunteers and images count in festival."""
+        url = reverse(FESTIVAL_URL_NAME, kwargs={"year": festival_2020.year})
+        response = client.get(url)
+        data = response.json()
+        objects_count_in_response = len(data.get(field))
+        objects_count_in_db = getattr(festival_2020, field).all().count()
+        assert (
+            objects_count_in_response == objects_count_in_db
+        ), f"Проверьте, что при GET запросе {url} возвращаются данные объекта. Значение {field} неправильное"
+
+    def test_get_festival_years(self, client, festival_2020):
+        """Check getting festival years."""
+        url = FESTIVAL_YEARS_URL
+        response = client.get(url)
+        data = response.json()
+        year_in_db = getattr(festival_2020, "year")
+        years_in_response = data.get("years")
+        assert (
+            year_in_db in years_in_response
+        ), f"Проверьте, что при GET запросе {url} возвращается список годов фестивалей"

--- a/apps/info/tests/tests_views/test_partners.py
+++ b/apps/info/tests/tests_views/test_partners.py
@@ -1,0 +1,92 @@
+import pytest
+from django.urls import reverse
+from rest_framework import status
+
+from apps.info.factories import PartnerFactory
+
+pytestmark = [pytest.mark.django_db]
+
+PARTNERS_URL = reverse("partners")
+
+
+@pytest.fixture
+def in_footer_general_partner():
+    return PartnerFactory(type="general", in_footer_partner=True)
+
+
+@pytest.fixture
+def general_partner():
+    return PartnerFactory(type="general")
+
+
+@pytest.fixture()
+def info_partner():
+    return PartnerFactory(type="info")
+
+
+@pytest.fixture()
+def festival_partner():
+    return PartnerFactory(type="festival")
+
+
+@pytest.fixture()
+def partners(in_footer_general_partner, general_partner, info_partner, festival_partner):
+    return in_footer_general_partner, general_partner, info_partner, festival_partner
+
+
+def test_partner_list_count_in_response_matches_count_in_db(client, partners):
+    """Checks that amount objects in response matches expected count."""
+    response_data = client.get(PARTNERS_URL).data
+    assert len(response_data) == 4
+
+
+@pytest.mark.parametrize(
+    "expected_attribute",
+    ("id", "name", "type", "url", "image", "in_footer_partner"),
+)
+def test_partner_list_fields(client, general_partner, expected_attribute):
+    """Check whether expected attribute found in returned object."""
+    response_data = client.get(PARTNERS_URL).data
+    partner_data = response_data[0]
+    assert expected_attribute in partner_data
+
+
+@pytest.mark.parametrize(
+    "in_footer_partner_param, expected_count",
+    (
+        (True, 1),
+        (False, 3),
+    ),
+)
+def test_partner_list_in_footer_partner_filter(client, in_footer_partner_param, expected_count, partners):
+    """Compare amount of objects in response with expected when `in_footer_partner` filter applied."""
+    query_params = {"in_footer_partner": in_footer_partner_param}
+
+    response_data = client.get(PARTNERS_URL, query_params).data
+    assert len(response_data) == expected_count
+
+
+@pytest.mark.parametrize(
+    "types_param, expected_count",
+    (
+        ("general", 2),
+        ("general,info", 3),
+        ("info,festival", 2),
+        ("general,info,festival", 4),
+    ),
+)
+def test_partner_list_in_types_filter(client, types_param, expected_count, partners):
+    """Compare amount of objects in response with expected when `types` filter applied."""
+    query_params = {"types": types_param}
+
+    response_data = client.get(PARTNERS_URL, query_params).data
+    assert len(response_data) == expected_count
+
+
+def test_partner_list_in_types_filter_incorrect_value(client, partners):
+    """Pass incorrect value to `types` filter and check for the error."""
+    query_params = {"types": "SOME_INCORRECT_VALUE"}
+
+    response = client.get(PARTNERS_URL, query_params)
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, "На недопустимое значение должны вернуть ошибку 400"
+    assert "types" in response.data, "Проверьте, что в списке ошибок есть ключ `types`."

--- a/apps/info/urls.py
+++ b/apps/info/urls.py
@@ -5,7 +5,7 @@ from apps.info.views import (
     FestivalAPIView,
     FestivalTeamsAPIView,
     FestivalYearsAPIView,
-    PartnersAPIView,
+    PartnerListAPIView,
     PressReleaseDownloadAPIView,
     PressReleaseViewSet,
     PressReleaseYearsAPIView,
@@ -54,8 +54,8 @@ info_urls = [
         include(about_festival_urls),
     ),
     path(
-        "partners/",
-        PartnersAPIView.as_view(),
+        route="partners/",
+        view=PartnerListAPIView.as_view(),
         name="partners",
     ),
     path(

--- a/apps/info/views/__init__.py
+++ b/apps/info/views/__init__.py
@@ -2,7 +2,7 @@ from apps.info.views.contacts import ContactsAPIView
 
 from .festival import FestivalAPIView, FestivalYearsAPIView
 from .festivalteams import FestivalTeamsAPIView
-from .partners import PartnersAPIView
+from .partners import PartnerListAPIView
 from .press_release import PressReleaseDownloadAPIView, PressReleaseViewSet, PressReleaseYearsAPIView
 from .selectors import SelectorsAPIView
 from .settings import SettingsAPIView
@@ -13,7 +13,7 @@ __all__ = (
     FestivalAPIView,
     FestivalTeamsAPIView,
     FestivalYearsAPIView,
-    PartnersAPIView,
+    PartnerListAPIView,
     PressReleaseViewSet,
     PressReleaseYearsAPIView,
     PressReleaseDownloadAPIView,

--- a/apps/info/views/partners.py
+++ b/apps/info/views/partners.py
@@ -1,22 +1,44 @@
 from drf_spectacular.utils import extend_schema
-from rest_framework.generics import ListAPIView
+from rest_framework import serializers
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
+from apps.core.fields import CharacterSeparatedSerializerField
+from apps.info import selectors
 from apps.info.models import Partner
-from apps.info.serializers import PartnerSerializer
 
 
-@extend_schema(
-    description="""**Endpoint for all partners.**
-    Query **type** accepts the type of partner:
-        *general partners*,
-         *partners of the festival*,
-         *information partners*.
-     Query **in_footer_partner** shows general partners in footer if *true*.
+class PartnerListAPIView(APIView):
+    class PartnerListFilterSerializer(serializers.Serializer):
+        in_footer_partner = serializers.BooleanField(
+            required=False,
+            help_text="Партнер отображается в футере",
+        )
+        types = CharacterSeparatedSerializerField(
+            child=serializers.ChoiceField(choices=Partner.PartnerType.choices),
+            required=False,
+            help_text="Тип партнера. Можно указать несколько значений разделенных запятой",
+        )
 
-    """
-)
-class PartnersAPIView(ListAPIView):
-    queryset = Partner.objects.all()
-    serializer_class = PartnerSerializer
-    filterset_fields = ("type", "in_footer_partner")
-    pagination_class = None
+    class PartnerListOutputSerializer(serializers.ModelSerializer):
+        class Meta:
+            model = Partner
+            fields = (
+                "name",
+                "type",
+                "url",
+                "image",
+                "in_footer_partner",
+            )
+
+    @extend_schema(
+        parameters=[PartnerListFilterSerializer],
+        responses=PartnerListOutputSerializer(many=True),
+    )
+    def get(self, request):
+        filter_serializer = self.PartnerListFilterSerializer(data=request.query_params, partial=True)
+        filter_serializer.is_valid(raise_exception=True)
+        response_data = selectors.partner_list(filters=filter_serializer.data)
+        context = {"request": request}
+        serializer = self.PartnerListOutputSerializer(response_data, context=context, many=True)
+        return Response(serializer.data)

--- a/apps/info/views/partners.py
+++ b/apps/info/views/partners.py
@@ -24,6 +24,7 @@ class PartnerListAPIView(APIView):
         class Meta:
             model = Partner
             fields = (
+                "id",
                 "name",
                 "type",
                 "url",


### PR DESCRIPTION
Тикет: [Добавить возможность фильтровать по массиву партнеров за раз](https://www.notion.so/1d2122db365b42568da17ea6a58a05fe?p=47b30558a6574941b66fcdfbe14a76e1)

Чтоб реализовать переписал view по стайлгайду, добавил тесты
Пришлось чуть реорганизовать как храним тесты.