### PR TITLE
Обновленный формат выдачи years-months у блогов и новостей.

### DIFF
--- a/apps/articles/selectors.py
+++ b/apps/articles/selectors.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from typing import Union
 
 from django.db.models import F, Prefetch, QuerySet
@@ -9,16 +10,32 @@ from apps.articles.filters import PubDateFilter
 from apps.articles.models import BlogItem, NewsItem, Project
 
 
-def article_get_years_months_publications(article_model: Union[BlogItem, NewsItem, Project]) -> QuerySet:
-    """Return distinct years and months of published BlogItem/NewsItem/Project."""
+def article_get_years_months_publications(
+    article_model: Union[BlogItem, NewsItem, Project]
+) -> dict[int, dict[int, list[int]]]:
+    """Return ordered list of years and months of published BlogItem/NewsItem.
+
+    The list is ordered by years (DESC). Each record should be a dict looked like this:
+        {
+            "year": 2020
+            "months": [2, 3, 10]  <-- ordered ASC
+        }
+    """
     publications_years_months_qs = (
         article_model.ext_objects.published()
         .annotate(year=F("pub_date__year"), month=F("pub_date__month"))
-        .values("year", "month")
+        .values_list("year", "month")
         .distinct()
         .order_by("-year", "month")
     )
-    return publications_years_months_qs
+
+    year_months_records = OrderedDict()
+    for year, month in publications_years_months_qs:
+        year_record = year_months_records.get(year, {"year": year, "months": []})
+        year_record["months"].append(month)
+        year_months_records[year] = year_record
+
+    return year_months_records.values()
 
 
 def blog_item_list_get(filters: dict[str, str] = None) -> QuerySet:

--- a/apps/articles/serializers/common.py
+++ b/apps/articles/serializers/common.py
@@ -9,8 +9,11 @@ class YearMonthSerializer(serializers.Serializer):
         max_value=timezone.now().year,
         help_text="Максимальный год равен текущему году",
     )
-    month = serializers.IntegerField(
-        label="Месяц",
-        min_value=1,
-        max_value=12,
+    months = serializers.ListSerializer(
+        child=serializers.IntegerField(
+            label="Месяц",
+            min_value=1,
+            max_value=12,
+        ),
+        label="Месяцы",
     )

--- a/apps/articles/tests/news_items/tests_views/test_news_years_months.py
+++ b/apps/articles/tests/news_items/tests_views/test_news_years_months.py
@@ -51,16 +51,42 @@ def news_item_4_2000_october():
 def test_news_item_years_months_fields(client, news_item_1_1995_november):
     """Verify that received objects has expected fields."""
     response_data = client.get(NEWS_YEARS_MONTH_URL).data
-    (year_month,) = response_data
+    (record,) = response_data
 
-    assert "year" in year_month
-    assert year_month["year"] == news_item_1_1995_november.pub_date.year
-    assert "month" in year_month
-    assert year_month["month"] == news_item_1_1995_november.pub_date.month
+    assert "year" in record
+    assert "months" in record
+
+
+def test_news_item_years_months_one_publication(client, news_item_1_1995_november):
+    """Verify the response with expected data when one there is one publication."""
+    expected_record = {
+        "year": news_item_1_1995_november.pub_date.year,
+        "months": [news_item_1_1995_november.pub_date.month],
+    }
+
+    response_data = client.get(NEWS_YEARS_MONTH_URL).data
+
+    assert len(response_data) == 1
+    (record,) = response_data
+    assert record == expected_record
+
+
+def test_news_item_years_months_distinct(client, news_item_1_1995_november, news_item_2_1995_november):
+    """Verify the response with expected data when there are two publication with same year and month."""
+    expected_record = {
+        "year": news_item_1_1995_november.pub_date.year,
+        "months": [news_item_1_1995_november.pub_date.month],
+    }
+
+    response_data = client.get(NEWS_YEARS_MONTH_URL).data
+
+    assert len(response_data) == 1
+    (record,) = response_data
+    assert record == expected_record
 
 
 def test_news_item_years_months_empty_when_blog_items_not_published(client, news_item_not_published):
-    """Count the amount of results. All `NewsItem` objects are not published and result should be empty."""
+    """Count the amount of results. All `BlogItem` objects are not published and result should be empty."""
     response_data = client.get(NEWS_YEARS_MONTH_URL).data
 
     assert len(response_data) == 0, "Not published objects should not influence years-month response."
@@ -70,19 +96,18 @@ def test_news_item_years_month_ordering(
     client, news_item_1_1995_november, news_item_3_2000_january, news_item_4_2000_october
 ):
     """The response should be ordered by years DESC and by month ASC."""
-    response_data = client.get(NEWS_YEARS_MONTH_URL).data
-    (first_data, second_data, third_data) = response_data
-
-    assert first_data["year"] == news_item_3_2000_january.pub_date.year
-    assert first_data["month"] == news_item_3_2000_january.pub_date.month
-    assert second_data["year"] == news_item_4_2000_october.pub_date.year
-    assert second_data["month"] == news_item_4_2000_october.pub_date.month
-    assert third_data["year"] == news_item_1_1995_november.pub_date.year
-    assert third_data["month"] == news_item_1_1995_november.pub_date.month
-
-
-def test_news_item_years_months_distinct(client, news_item_1_1995_november, news_item_2_1995_november):
-    """Years-month objects should be distinct in response."""
+    first_expected_record = {
+        "year": news_item_3_2000_january.pub_date.year,
+        "months": [news_item_3_2000_january.pub_date.month, news_item_4_2000_october.pub_date.month],
+    }
+    second_expected_record = {
+        "year": news_item_1_1995_november.pub_date.year,
+        "months": [news_item_1_1995_november.pub_date.month],
+    }
     response_data = client.get(NEWS_YEARS_MONTH_URL).data
 
-    assert len(response_data) == 1, "The object `years-month` has to be unique in response."
+    assert len(response_data) == 2
+
+    (first_record, second_record) = response_data
+    assert first_record == first_expected_record
+    assert second_record == second_expected_record


### PR DESCRIPTION
Тикет: [Отрефакторить years-months у новостей и блогов](https://www.notion.so/1d2122db365b42568da17ea6a58a05fe?p=f03d83fe33cf487a80573ae1d24d9e88) + обновленные тесты.

Раньше записи отдавали в таком виде:
```
  {
    "year": 1993,
    "month": 3
  },
  {
    "year": 1993,
    "month": 7
  }
```

Теперь в таком:
```
    {
        "year": 1993,
        "months": [
            3,
            7
        ]
    },
```