### PR TITLE
Bugfix/fix get value setting admin

### DIFF
--- a/apps/main/admin.py
+++ b/apps/main/admin.py
@@ -61,9 +61,7 @@ class SettingAdmin(admin.ModelAdmin):
         """Return value of the setting object."""
         if isinstance(obj.value, bool):
             return _boolean_icon(obj.value)
-        if obj.field_type == "IMAGE":
-            if not obj.value:
-                return None
+        if obj.field_type == "IMAGE" and obj.value:
             return format_html('<a href="{}">{}</a>'.format(obj.image.url, obj.value))
         if obj.field_type == "URL":
             return format_html('<a href="{}">{}</a>'.format(obj.url, obj.value))

--- a/apps/main/admin.py
+++ b/apps/main/admin.py
@@ -62,6 +62,8 @@ class SettingAdmin(admin.ModelAdmin):
         if isinstance(obj.value, bool):
             return _boolean_icon(obj.value)
         if obj.field_type == "IMAGE":
+            if not obj.value:
+                return None
             return format_html('<a href="{}">{}</a>'.format(obj.image.url, obj.value))
         if obj.field_type == "URL":
             return format_html('<a href="{}">{}</a>'.format(obj.url, obj.value))


### PR DESCRIPTION
Тикет вашего PR (если есть):
    ___[ваш тикет](https://www.notion.so/500-273f08dac0554a84b657feda460b4089)___

**Шаг 1** Открыть [https://stage.dev.lubimovka.ru/admin/](https://stage.dev.lubimovka.ru/admin/main/settingmain/28/change/)

**Шаг 2** Войти как админ (login: admin, password: admin)

**Шаги для воспроизведения:**

1. Шаг 1 В админке открыть “Настройки приложения” → Настройки главной страницы → **[[Фото для видео-архива на главной странице](https://stage.dev.lubimovka.ru/admin/main/settingmain/28/change/)](https://stage.dev.lubimovka.ru/admin/main/settingmain/28/change/)**
2. Шаг 2 Поставить галочку в чек-боксе напротив “Удалить изображение”
3. Шаг 3 Сохранить изменения
4. Шаг 4 Открыть сайт [https://stage.dev.lubimovka.ru/](https://stage.dev.lubimovka.ru/admin/main/settingmain/28/change/) и пролистать до блока “Видео-архив всех читок и событий”

**Фактический результат: Ошибка 500**

**Ожидаемый результат: Открывается главная страница любимовки, в блоке “Видео-архив всех читок и событий” нет изображения.**



Ошибка возникала из-за отсутствия проверки на наличие изображения в методе get_value в SettingAdmin
