### PR TITLE
Feature/admin fest mode switch

### DIFF
--- a/apps/core/models.py
+++ b/apps/core/models.py
@@ -230,6 +230,7 @@ class Setting(BaseModel):
                     "main_add_news": False,
                     "main_add_places": True,
                     "main_add_short_list": False,
+                    "main_show_afisha_only_for_today": True,
                 }
             },
             False: {
@@ -238,6 +239,7 @@ class Setting(BaseModel):
                     "main_add_news": True,
                     "main_add_places": False,
                     "main_add_short_list": True,
+                    "main_show_afisha_only_for_today": False,
                 }
             },
         }

--- a/apps/core/models.py
+++ b/apps/core/models.py
@@ -371,7 +371,6 @@ class Setting(BaseModel):
 
     @classmethod
     def _check_triggers(cls, setting):
-        print("Checking triggers for:", setting)
         if setting.settings_key in cls.TRIGGERS:
             preset = cls.TRIGGERS[setting.settings_key]
             for model, settings in preset.get(setting.boolean, {}).items():

--- a/apps/main/models.py
+++ b/apps/main/models.py
@@ -78,6 +78,30 @@ class SettingGeneral(Setting):
         verbose_name = "Общие настройки"
         verbose_name_plural = "Общие настройки"
 
+    def save(self, *args, **kwargs):
+        if self.settings_key == "festival_status":
+            if self.boolean:
+                self._set_settings(
+                    {
+                        "main_add_blog": True,
+                        "main_add_news": False,
+                        "main_add_places": True,
+                        "main_add_short_list": False,
+                        "main_show_afisha_only_for_today": True,
+                    }
+                )
+            else:
+                self._set_settings(
+                    {
+                        "main_add_blog": False,
+                        "main_add_news": True,
+                        "main_add_places": False,
+                        "main_add_short_list": True,
+                        "main_show_afisha_only_for_today": False,
+                    }
+                )
+        return super().save(*args, **kwargs)
+
 
 class SettingMain(Setting):
     objects = SettingGroupManager()
@@ -87,6 +111,24 @@ class SettingMain(Setting):
         proxy = True
         verbose_name = "Настройки главной страницы"
         verbose_name_plural = "Настройки главной страницы"
+
+    def save(self, *args, **kwargs):
+        if self.settings_key == "main_add_news":
+            if self.boolean:
+                self._set_settings(
+                    {
+                        "main_add_blog": False,
+                    }
+                )
+        if self.settings_key == "main_add_blog":
+            if self.boolean:
+                self._set_settings(
+                    {
+                        "main_add_news": False,
+                    }
+                )
+
+        return super().save(*args, **kwargs)
 
 
 class SettingFirstScreen(Setting):


### PR DESCRIPTION
Тикет вашего PR (если есть):
    ___[Автоматическое переключение настроек главной страницы](https://www.notion.so/814e43673ac347389638d96aabe43c53)___

- добавлено автоматическое изменение настроек главной страницы при изменении статуса фестиваля; задействованы следующие настройки: Отображение дневника на главной странице, Отображение площадок на главной странице, Отображение афиши только на сегодня (в противном случае отображаются ближайшие 6 событий), Отображение новостей на главной странице, Отображение шорт-листа на главной странице
- при активном статусе фестиваля включены настройки: Отображение дневника на главной странице, Отображение площадок на главной странице, Отображение афиши только на сегодня (в противном случае отображаются ближайшие 6 событий); остальные - выключены.
- при неактивном статусе фестиваля активны настройки: Отображение новостей на главной странице, Отображение шорт-листа на главной странице; остальные - выключены.
