### PR TITLE
Feature/admin pressrelease editor styles

### DIFF
--- a/apps/core/static/core/ckeditor/press-release-styles.css
+++ b/apps/core/static/core/ckeditor/press-release-styles.css
@@ -1,3 +1,13 @@
+@page {
+    size: A4;
+    @frame content_frame {
+        left: 2cm;
+        width: 17.5cm;
+        top: 1.5cm;
+        height: 26cm;
+    }
+}
+
 @font-face {
     font-family: "PP Neue Machina";
     font-style: normal;
@@ -47,13 +57,9 @@
     font-weight: normal;
     font-size: 20px;
     line-height: 28px;
-    text-indent: 50px;
+    text-indent: 20px;
     letter-spacing: -0.01em;
     font-feature-settings: 'ss01' on;
-
-    /* Adjust block margin */
-    margin-block-start: 0.5em;
-    margin-block-end: 0.5em;
 }
 
 
@@ -66,9 +72,6 @@ p {
     letter-spacing: -0.01em;
     font-feature-settings: 'ss01' on;
 
-    /* Adjust block margin */
-    margin-block-start: 0.5em;
-    margin-block-end: 0.5em;
 }
 
 h1 {

--- a/apps/info/templates/press_release.html
+++ b/apps/info/templates/press_release.html
@@ -10,7 +10,7 @@
 </head>
 
 <body>
-    <div class="text">{{ press_release.text | safe }}</div>
+    <div class="text">{{ text | safe }}</div>
 </body>
 
 </html>

--- a/apps/info/utils.py
+++ b/apps/info/utils.py
@@ -1,4 +1,5 @@
 import random
+import unicodedata
 from pathlib import Path
 
 from django.conf import settings
@@ -44,7 +45,7 @@ def get_pdf_response(press_release_instance):
         styles = file.read()
     content = template.render(
         {
-            "press_release": press_release_instance,
+            "text": unicodedata.normalize("NFC", press_release_instance.text),
             "styles": styles,
         }
     )


### PR DESCRIPTION
Тикет вашего PR (если есть):
    ___[Добавить стили + шрифт для пресс-релизов](https://www.notion.so/98346175885a4c79b1c9d80ab4c19083)___
Продолжение PR #530 

- ликвидирована проблема букв "ё" и "й" в пресс-релизах, скопированных через буфер обмена с web-страниц
- изменен макет пресс-релиза
