### PR TITLE
change get_first_letter, author_admin

### DIFF
--- a/apps/library/serializers/author.py
+++ b/apps/library/serializers/author.py
@@ -78,6 +78,8 @@ class AuthorSearchSerializer(serializers.ModelSerializer):
     first_letter = serializers.SerializerMethodField()
 
     def get_first_letter(self, obj) -> str:
+        if not obj.person.last_name:
+            return obj.person.first_name[0].upper()
         return obj.person.last_name[0].upper()
 
     class Meta:

--- a/apps/library/static/admin/author_admin.js
+++ b/apps/library/static/admin/author_admin.js
@@ -38,8 +38,7 @@ jQuery(document).ready(function ($) {
     jQuery(function($) {
         $('#id_person').on('select2:select', function() {
             var fullName = $('#id_person').select2('data')[0].text;
-            var lastName = fullName.replace(/ .*/,'');
-            $('#id_slug').val(URLify(lastName));
+            $('#id_slug').val(URLify(fullName));
         });
     });
 });


### PR DESCRIPTION
Тикет вашего PR (если есть):
    ___[ваш тикет](https://www.notion.so/500-cf6d9b1467034544b2dd10160a7dc46f)___

Было настроено так что метод `get_first_letter` в сериализаторе `AuthorSearchSerializer` искал первую букву только в фамилии. Перестроил чтобы в случае отсутствия фамилии искал в имени.

При отсутствии фамилии автослаг не работал. Решил что может лучше формировать слаг по полной фамилии и имени на случай если фамилии будут одинаковыми. 