### PR TITLE
Admin - Hide PR-director field in advance

### DIFF
--- a/apps/info/admin/festival.py
+++ b/apps/info/admin/festival.py
@@ -232,4 +232,5 @@ class FestTeamMemberAdmin(SortableAdminMixin, admin.ModelAdmin):
     class Media:
         """Adds a script that displays the field ```pr_director_name``` if ```is_pr_director``` is selected."""
 
+        css = {"all": ("admin/info/css/pr.css",)}
         js = ("admin/info/js/FestivalTeamFooter.js",)

--- a/apps/info/static/admin/info/css/pr.css
+++ b/apps/info/static/admin/info/css/pr.css
@@ -1,0 +1,1 @@
+div.field-pr_director_name {display: none;}


### PR DESCRIPTION
Тикет вашего PR (если есть):
    ___[Админ/Арт-Дирекция фестиваля/Добавить Арт-дирекция фестиваля/ при первой загрузке страницы виден момент скрытия поля с данными о PR-менеджере. Нужно убрать](https://www.notion.so/PR-247bf82b2d604d999d5f8bcb352be25e)___

- поле PR-директора скрывается с помощью стиля в настройках формы (не проявляется с самого начала загрузки страницы).