### PR TITLE
delete show_general_partners, show_info_partners_and_festival_partner…

### DIFF
--- a/apps/info/selectors/settings.py
+++ b/apps/info/selectors/settings.py
@@ -1,9 +1,7 @@
-from typing import Union
-
 from apps.core.models import Person, Setting
 
 
-def info_settings_get() -> dict[str, Union[str, bool, dict[str, str]]]:
+def info_settings_get() -> object:
     """Return settings (mostly related to emails) dictionary."""
     settings_keys = (
         "play_author_email",

--- a/apps/info/tests/tests_views/test_partners.py
+++ b/apps/info/tests/tests_views/test_partners.py
@@ -42,28 +42,13 @@ def test_partner_list_count_in_response_matches_count_in_db(client, partners):
 
 @pytest.mark.parametrize(
     "expected_attribute",
-    ("id", "name", "type", "description", "url", "image", "in_footer_partner"),
+    ("id", "name", "type", "description", "url", "image"),
 )
 def test_partner_list_fields(client, general_partner, expected_attribute):
     """Check whether expected attribute found in returned object."""
     response_data = client.get(PARTNERS_URL).data
     partner_data = response_data[0]
     assert expected_attribute in partner_data
-
-
-@pytest.mark.parametrize(
-    "in_footer_partner_param, expected_count",
-    (
-        (True, 1),
-        (False, 3),
-    ),
-)
-def test_partner_list_in_footer_partner_filter(client, in_footer_partner_param, expected_count, partners):
-    """Compare amount of objects in response with expected when `in_footer_partner` filter applied."""
-    query_params = {"in_footer_partner": in_footer_partner_param}
-
-    response_data = client.get(PARTNERS_URL, query_params).data
-    assert len(response_data) == expected_count
 
 
 @pytest.mark.parametrize(

--- a/apps/info/views/partners.py
+++ b/apps/info/views/partners.py
@@ -14,10 +14,6 @@ class PartnerListAPIView(APIView):
             required=False,
             help_text="Генеральный партнер",
         )
-        in_footer_partner = serializers.BooleanField(
-            required=False,
-            help_text="Партнер отображается в футере",
-        )
         types = CharacterSeparatedSerializerField(
             child=serializers.ChoiceField(choices=Partner.PartnerType.choices),
             required=False,
@@ -35,7 +31,6 @@ class PartnerListAPIView(APIView):
                 "url",
                 "image",
                 "description",
-                "in_footer_partner",
             )
 
     @extend_schema(

--- a/apps/main/serializers.py
+++ b/apps/main/serializers.py
@@ -93,13 +93,6 @@ class MainVideoArchiveSerializer(serializers.Serializer):
     photo = serializers.ImageField()
 
 
-class PartnersSettingsSerializer(serializers.Serializer):
-    """Returns settings defining to show or not Partners."""
-
-    show_general_partners = serializers.BooleanField()
-    show_info_partners_and_festival_partners = serializers.BooleanField()
-
-
 @extend_schema_serializer(
     OpenApiExample(
         name="Schema for main",
@@ -116,4 +109,3 @@ class MainSerializer(serializers.Serializer):
     short_list = MainShortListSerializer(required=False)
     places = MainPlacesSerializer(required=False)
     video_archive = MainVideoArchiveSerializer(required=False)
-    show_partners = PartnersSettingsSerializer(required=True)

--- a/apps/main/tests/test_views.py
+++ b/apps/main/tests/test_views.py
@@ -23,7 +23,6 @@ class TestMainAPIViews:
             "short_list",
             "places",
             "video_archive",
-            "show_partners",
         ]
         response = client.get(MAIN_URL)
         for field in fields:
@@ -88,18 +87,6 @@ class TestMainAPIViews:
             assert (
                 field in response.data["video_archive"]
             ), f"Проверьте, что при GET запросе {MAIN_URL} data[video_archive] содержит items"
-
-    def test_get_main_settings_fields(self, client):
-        """Checks data["show_partners"] fields in response."""
-        fields = [
-            "show_general_partners",
-            "show_info_partners_and_festival_partners",
-        ]
-        response = client.get(MAIN_URL)
-        for field in fields:
-            assert (
-                field in response.data["show_partners"]
-            ), f"Проверьте, что при GET запросе {MAIN_URL} data[show_partners] содержит {field}"
 
     def test_news_count_in_response_matches_count_in_db(self, client, news_items_with_content):
         """Checks that count news in response matches count in db."""

--- a/apps/main/views.py
+++ b/apps/main/views.py
@@ -18,7 +18,6 @@ class MainView(APIView):
         main.add_short_list()
         main.add_video_archive()
         main.add_places()
-        main.show_partners()
         # Common access to context. It's required to return correct url links
         context = {
             "request": self.request,


### PR DESCRIPTION
…s, in_footer_partner

Тикет вашего PR (если есть):
    ___[ваш тикет](https://www.notion.so/in_footer_partner-c9e59c0295144debb1181fae88825494)___

Лишние поля ручки главной страницы, так же `in_footer_partner`
 у партнера

Убрал эти поля с главной страницы и у партнёров поле `in_footer_partner`