### PR TITLE
Fix field name in Event serializer

### DIFF
--- a/apps/content_pages/serializers/content_blocks.py
+++ b/apps/content_pages/serializers/content_blocks.py
@@ -26,7 +26,7 @@ class EventInBlockSerializer(serializers.ModelSerializer):
             "event_body",
             "date_time",
             "url",
-            "button",
+            "action",
         )
 
 


### PR DESCRIPTION
Тикет вашего PR (если есть):
    ___нет___

- исправлена ошибка точки /api/v1/schema/ связанная с переименованием поля button в модели Event