### PR TITLE
Fix issue with NoneBooleanField removed from DRF

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -365,7 +365,7 @@ python-versions = "*"
 
 [[package]]
 name = "djangorestframework"
-version = "3.14.0"
+version = "3.13.1"
 description = "Web APIs for Django, made easy."
 category = "main"
 optional = false


### PR DESCRIPTION
DRF 3.14 has no support of NoneBooleanField

Тикет вашего PR (если есть):
    ___нет___

- откат на версию Django Rest Framework 3.13.1 для решения проблемы несовместимости с другими пакетами
(см. также https://stackoverflow.com/questions/73823833/attributeerror-module-rest-framework-serializers-has-no-attribute-nullboolea/73827398)
- необходимо проверить работоспособность точки API https://stage.dev.lubimovka.ru/api/v1/schema/
