### PR TITLE
Add setting for debug toolbar urls

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -16,6 +16,7 @@ APPS_DIR = ROOT_DIR / "apps"
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#debug
 DEBUG = env.bool("DJANGO_DEBUG", default=True)
+FORCE_DEBUG_TOOLBAR_URLS = env.bool("FORCE_DEBUG_TOOLBAR_URLS", default=False)
 
 # https://docs.djangoproject.com/en/dev/ref/settings/#secret-key
 SECRET_KEY = env("DJANGO_SECRET_KEY", default="")

--- a/config/urls.py
+++ b/config/urls.py
@@ -8,6 +8,7 @@ from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, Spec
 from apps.core.views import error400, error404, error500
 
 DEBUG = settings.DEBUG
+FORCE_DEBUG_TOOLBAR_URLS = settings.FORCE_DEBUG_TOOLBAR_URLS
 MEDIA_URL = settings.MEDIA_URL
 MEDIA_ROOT = settings.MEDIA_ROOT
 
@@ -69,7 +70,7 @@ urlpatterns = [
 ] + static(MEDIA_URL, document_root=MEDIA_ROOT)
 
 
-if DEBUG:
+if DEBUG or FORCE_DEBUG_TOOLBAR_URLS:
     import debug_toolbar
 
     urlpatterns += [


### PR DESCRIPTION
Тикет вашего PR (если есть):
    ___[404 ошибка при попытке выбрать другую пьесу на странице Изменить Спектакль](https://www.notion.so/404-4326c7389d48445396653846055995aa)___

- добавлена отдельная настройка, чтобы подключать служебные url для django debug toolbar при выключенном отладочном режиме (как на stage-сервере); это должно решить проблему внезапной ошибки 404.
- для работы нужно установить переменную среды на сервере FORCE_DEBUG_TOOLBAR_URLS=1