### PR TITLE
Load DDT urls when toolbar installed

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -69,7 +69,7 @@ urlpatterns = [
 ] + static(MEDIA_URL, document_root=MEDIA_ROOT)
 
 
-if DEBUG:
+if "debug_toolbar" in settings.INSTALLED_APPS:
     import debug_toolbar
 
     urlpatterns += [


### PR DESCRIPTION
Тикет вашего PR (если есть):
    ___[404 ошибка при попытке выбрать другую пьесу на странице Изменить Спектакль](https://www.notion.so/404-4326c7389d48445396653846055995aa)___

- исправлена ошибка конфигурирования Django Debug Toolbar при отключенном отладочном режиме
