### PR TITLE
field name fix for event serializer

### DIFF
--- a/apps/afisha/serializers/performance.py
+++ b/apps/afisha/serializers/performance.py
@@ -10,7 +10,7 @@ class LocalEventSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Event
-        fields = ("id", "date_time", "url")
+        fields = ("id", "date_time", "action_url")
 
 
 class BlockImagesSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
Фикс названия поля из-за которого падала ручка `api/v1/afisha/performances/{id}/`