### PR TITLE
duration value changed to seconds (int)

### DIFF
--- a/apps/afisha/serializers/performance.py
+++ b/apps/afisha/serializers/performance.py
@@ -1,3 +1,4 @@
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from apps.afisha.models import Event, Performance, PerformanceMediaReview, PerformanceReview
@@ -35,6 +36,12 @@ class PerformanceSerializer(serializers.ModelSerializer):
     team = RoleSerializer(many=True)
     images_in_block = BlockImagesSerializer(many=True)
     events = LocalEventSerializer(source="events.body", many=True)
+    duration = serializers.SerializerMethodField()
+
+    @extend_schema_field(int)
+    def get_duration(self, obj):
+        """Retruns duration in seconds instead of default HH:MM:SS format."""
+        return obj.duration.seconds
 
     class Meta:
         exclude = (

--- a/apps/feedback/services/participation_export.py
+++ b/apps/feedback/services/participation_export.py
@@ -34,7 +34,7 @@ class ParticipationApplicationExport:
         return Setting.get_settings(settings_keys=settings_keys)
 
     def mail_send_export(self, instance, file_link):
-        email_settings = self.get_email_settings(self)
+        email_settings = self.get_email_settings()
         from_email = email_settings.get("email_send_from")
         to_emails = (email_settings.get("submit_play_email"),)
         template_id = settings.MAILJET_TEMPLATE_ID_PARTICIPATION_APPLICATION


### PR DESCRIPTION
В ответе апи для ручки `/api/v1/afisha/performances/{id}/` значение поля `duration` заменено на целочисленное  (секунды) для удобства обработки на фронте.

Также убран лишний аргумент `self` при вызове функции `get_email_settings` (продолжение [тикета](https://www.notion.so/e2e20e32d32a44fa8b9b15bf4d2fee80) с настройками почт)