### PR TITLE
feature/add play links to the api serializer OrderedPlaySerializer

### DIFF
--- a/apps/articles/tests/blog_items/tests_views/test_blog_item_detail.py
+++ b/apps/articles/tests/blog_items/tests_views/test_blog_item_detail.py
@@ -104,6 +104,8 @@ def test_blog_item_detail_plays_block_content_fields(client, complex_blog_item):
         "authors",
         "city",
         "year",
+        "url_download",
+        "url_download_from",
     )
 
     for order, field in enumerate(first_play):

--- a/apps/articles/tests/blog_items/tests_views/test_blog_item_detail.py
+++ b/apps/articles/tests/blog_items/tests_views/test_blog_item_detail.py
@@ -104,7 +104,7 @@ def test_blog_item_detail_plays_block_content_fields(client, complex_blog_item):
         "authors",
         "city",
         "year",
-        "url_download",
+        "url_reading",
         "url_download_from",
     )
 

--- a/apps/articles/tests/blog_items/tests_views/test_blog_item_detail.py
+++ b/apps/articles/tests/blog_items/tests_views/test_blog_item_detail.py
@@ -104,7 +104,7 @@ def test_blog_item_detail_plays_block_content_fields(client, complex_blog_item):
         "authors",
         "city",
         "year",
-        "url_reading",
+        "url_download",
         "url_download_from",
     )
 

--- a/apps/content_pages/serializers/content_items.py
+++ b/apps/content_pages/serializers/content_items.py
@@ -100,9 +100,9 @@ class OrderedPlaySerializer(serializers.Serializer):
         required=False,
         label="Год написания пьесы",
     )
-    url_reading = serializers.URLField(
-        source="item.url_reading",
-        label="Ссылка на читку",
+    url_download = serializers.URLField(
+        source="item.url_download",
+        label="Текст пьесы",
         max_length=200,
     )
     url_download_from = serializers.URLField(

--- a/apps/content_pages/serializers/content_items.py
+++ b/apps/content_pages/serializers/content_items.py
@@ -100,6 +100,16 @@ class OrderedPlaySerializer(serializers.Serializer):
         required=False,
         label="Год написания пьесы",
     )
+    url_download = serializers.IntegerField(
+        source="item.url_download",
+        label="Ссылка на читку",
+        max_length=200,
+    )
+    url_download_from = serializers.IntegerField(
+        source="item.url_download_from",
+        label="Ссылка на скачивание",
+        max_length=200,
+    )
 
 
 class OrderedVideoSerializer(serializers.ModelSerializer):

--- a/apps/content_pages/serializers/content_items.py
+++ b/apps/content_pages/serializers/content_items.py
@@ -100,12 +100,12 @@ class OrderedPlaySerializer(serializers.Serializer):
         required=False,
         label="Год написания пьесы",
     )
-    url_download = serializers.IntegerField(
+    url_download = serializers.URLField(
         source="item.url_download",
         label="Ссылка на читку",
         max_length=200,
     )
-    url_download_from = serializers.IntegerField(
+    url_download_from = serializers.URLField(
         source="item.url_download_from",
         label="Ссылка на скачивание",
         max_length=200,

--- a/apps/content_pages/serializers/content_items.py
+++ b/apps/content_pages/serializers/content_items.py
@@ -100,8 +100,8 @@ class OrderedPlaySerializer(serializers.Serializer):
         required=False,
         label="Год написания пьесы",
     )
-    url_download = serializers.URLField(
-        source="item.url_download",
+    url_reading = serializers.URLField(
+        source="item.url_reading",
         label="Ссылка на читку",
         max_length=200,
     )


### PR DESCRIPTION
Тикет вашего PR (если есть):
[ Добавить ссылки на пьесу в данных блока пьес](https://www.notion.so/c5a26c5ab23b49b4b5fd5b5a26163920)
Для точек API собираемых из конструктора, например /api/v1/news/{id}/ в данные пьесы (content type playsblock в JSON ответа, а в нем - список items в content_item) и на сам сайт блога blog/{id}/ в секцию с автором, городом и годом, добавлены ссылка на текст и ссылка для скачивания пьесы. Теперь в блоге в блоке добавленной пьесы будут данные ссылки (поля url_download, url_download_from из модели пьесы)

