### PR TITLE
Remove duplicates from play list

### DIFF
--- a/apps/library/views/play.py
+++ b/apps/library/views/play.py
@@ -13,5 +13,5 @@ class PlayViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
     def get_queryset(self):
         params = set(self.request.query_params)
         if params and params.intersection(set(self.filterset_class.get_filters())):
-            return super().get_queryset()
+            return super().get_queryset().distinct("name")
         return super().get_queryset().order_by("?")


### PR DESCRIPTION
Тикет вашего PR (если есть):
    ___нет___

- исправлена ошибка /api/v1/library/plays/  - выдача дубликатов пьес, которые зарегистрированы в нескольких программах, когда используются фильтры по году фестиваля или программам.