### PR TITLE
Bugfix/api refine author name

### DIFF
--- a/apps/core/models.py
+++ b/apps/core/models.py
@@ -113,11 +113,11 @@ class Person(BaseModel):
     @property
     @admin.display(description="Фамилия и имя")
     def full_name(self) -> str:
-        return f"{self.last_name} {self.first_name}"
+        return f"{self.last_name} {self.first_name}".strip()
 
     @property
     def reversed_full_name(self):
-        return f"{self.last_name} {self.first_name}"
+        return f"{self.last_name} {self.first_name}".strip()
 
 
 class Role(BaseModel):

--- a/apps/library/serializers/author.py
+++ b/apps/library/serializers/author.py
@@ -75,19 +75,12 @@ class AuthorSearchSerializer(serializers.ModelSerializer):
         slug_field="reversed_full_name",
         read_only=True,
     )
-    first_letter = serializers.SerializerMethodField()
-
-    def get_first_letter(self, obj) -> str:
-        if not obj.person.last_name:
-            return obj.person.first_name[0].upper()
-        return obj.person.last_name[0].upper()
 
     class Meta:
         model = Author
         fields = (
             "slug",
             "name",
-            "first_letter",
         )
 
 


### PR DESCRIPTION
Тикет вашего PR (если есть):
    ___нет___

- если у автора нет фамилии, его полное имя печатается без пробела в начале строки в ответах API /api/v1/library/search/
- в ответе API /api/v1/library/search/ не выводится поле first_letter