### PR TITLE
Custom field type for adding domain

### DIFF
--- a/apps/afisha/serializers/performance.py
+++ b/apps/afisha/serializers/performance.py
@@ -2,8 +2,8 @@ from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from apps.afisha.models import Event, Performance, PerformanceMediaReview, PerformanceReview
+from apps.core.fields import DomainPrependField
 from apps.core.models import Image
-from apps.core.utils import get_domain
 from apps.library.serializers import PlaySerializer, RoleSerializer
 
 
@@ -20,10 +20,7 @@ class LocalEventSerializer(serializers.ModelSerializer):
 class BlockImagesSerializer(serializers.ModelSerializer):
     """Сериализатор блока изображений."""
 
-    url = serializers.SerializerMethodField()
-
-    def get_url(self, obj) -> str:
-        return get_domain(self.context["request"]) + str(obj.image.url)
+    url = DomainPrependField(source="image", slug_field="url", read_only=True)
 
     class Meta:
         model = Image

--- a/apps/content_pages/serializers/content_items.py
+++ b/apps/content_pages/serializers/content_items.py
@@ -1,8 +1,8 @@
 from rest_framework import serializers
 
 from apps.content_pages.models import Link, OrderedImage, OrderedVideo
+from apps.core.mixins import GetDomainMixin
 from apps.core.serializers import PersonRoleSerializer
-from apps.core.utils import get_domain
 from apps.library.serializers import AuthorForPlaySerializer as LibraryPlayAuthorSerializer
 
 
@@ -75,7 +75,7 @@ class OrderedImageSerializer(serializers.ModelSerializer):
         )
 
 
-class OrderedPlaySerializer(serializers.Serializer):
+class OrderedPlaySerializer(GetDomainMixin, serializers.Serializer):
     id = serializers.IntegerField(
         source="item.id",
         label="ID",
@@ -112,7 +112,7 @@ class OrderedPlaySerializer(serializers.Serializer):
         if obj.item.url_download_from:
             return obj.item.url_download_from
         else:
-            return get_domain(self.context["request"]) + obj.item.url_download.url
+            return self.prepend_domain(obj.item.url_download.url)
 
 
 class OrderedVideoSerializer(serializers.ModelSerializer):

--- a/apps/core/fields.py
+++ b/apps/core/fields.py
@@ -1,5 +1,7 @@
 from rest_framework import serializers
 
+from apps.core.utils import get_domain
+
 
 class CharacterSeparatedSerializerField(serializers.ListField):
     """Character separated ListField.
@@ -30,3 +32,8 @@ class CharacterSeparatedSerializerField(serializers.ListField):
     def to_representation(self, data):
         data = super().to_representation(data)
         return self.separator.join(data)
+
+
+class DomainPrependField(serializers.SlugRelatedField):
+    def to_representation(self, obj):
+        return get_domain(self.context["request"]) + str(super().to_representation(obj))

--- a/apps/core/mixins.py
+++ b/apps/core/mixins.py
@@ -3,7 +3,7 @@ from django.http import HttpResponseRedirect
 from django.utils.html import format_html
 
 from apps.core.constants import STATUS_INFO, Status
-from apps.core.utils import get_object, get_user_change_perms_for_status, get_user_perms_level
+from apps.core.utils import get_domain, get_object, get_user_change_perms_for_status, get_user_perms_level
 
 
 class StatusButtonMixin:
@@ -147,3 +147,10 @@ class HideOnNavPanelAdminModelMixin:
 
     def has_module_permission(self, request):
         return False
+
+
+class GetDomainMixin:
+    """Serializer mixin to generate URLs with domain."""
+
+    def prepend_domain(self, url):
+        return get_domain(self.context["request"]) + str(url)

--- a/apps/library/serializers/play.py
+++ b/apps/library/serializers/play.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from apps.core.utils import get_domain
+from apps.core.mixins import GetDomainMixin
 from apps.library.models import Author, Play
 
 
@@ -14,7 +14,7 @@ class AuthorForPlaySerializer(serializers.ModelSerializer):
         fields = ("name", "slug")
 
 
-class PlaySerializer(serializers.ModelSerializer):
+class PlaySerializer(GetDomainMixin, serializers.ModelSerializer):
     """Сериализатор Пьесы."""
 
     authors = AuthorForPlaySerializer(many=True)
@@ -27,7 +27,7 @@ class PlaySerializer(serializers.ModelSerializer):
         if obj.url_download_from:
             return obj.url_download_from
         else:
-            return get_domain(self.context["request"]) + obj.url_download.url
+            return self.prepend_domain(obj.url_download.url)
 
     class Meta:
         fields = (


### PR DESCRIPTION
Тикет вашего PR (если есть):
   [Сделать url изображений в ответе /api/v1/afisha/performances/{id}/ абсолютным](https://www.notion.so/url-api-v1-afisha-performances-id-2cd7e4b3f1f74da5b6db9a71cf9c5532)

Продолжение https://github.com/Studio-Yandex-Practicum/Lubimovka_backend/pull/668

- для галереи изображений выдаются абсолютные URL; реализовано пользовательское поле для добавления домена к URL.