### PR TITLE
min and max limits for year field removed

### DIFF
--- a/apps/articles/views/blog_items.py
+++ b/apps/articles/views/blog_items.py
@@ -1,4 +1,3 @@
-from django.utils import timezone
 from drf_spectacular.utils import extend_schema
 from rest_framework import serializers
 from rest_framework.response import Response
@@ -20,8 +19,6 @@ class BlogItemListAPI(APIView):
 
     class BlogItemListFilterSerializer(serializers.Serializer):
         year = serializers.IntegerField(
-            min_value=1970,
-            max_value=timezone.now().year,
             required=False,
             help_text="Фильтр по году",
         )

--- a/apps/feedback/views/participation.py
+++ b/apps/feedback/views/participation.py
@@ -1,7 +1,6 @@
 import logging
 import threading
 
-from django.utils import timezone
 from drf_spectacular.utils import extend_schema
 from rest_framework import serializers, status
 from rest_framework.response import Response
@@ -31,13 +30,9 @@ class ParticipationViewSet(APIView):
 
     class ParticipationSerializer(serializers.ModelSerializer):
         year = serializers.IntegerField(
-            min_value=1900,
-            max_value=timezone.now().year,
             label="Год написания",
         )
         birth_year = serializers.IntegerField(
-            min_value=1900,
-            max_value=timezone.now().year,
             label="Год рождения",
         )
         url_file_in_storage = serializers.URLField(read_only=True)

--- a/apps/feedback/views/participation.py
+++ b/apps/feedback/views/participation.py
@@ -1,6 +1,7 @@
 import logging
 import threading
 
+from django.utils import timezone
 from drf_spectacular.utils import extend_schema
 from rest_framework import serializers, status
 from rest_framework.response import Response
@@ -30,9 +31,13 @@ class ParticipationViewSet(APIView):
 
     class ParticipationSerializer(serializers.ModelSerializer):
         year = serializers.IntegerField(
+            min_value=1900,
+            max_value=timezone.now().year,
             label="Год написания",
         )
         birth_year = serializers.IntegerField(
+            min_value=1900,
+            max_value=timezone.now().year,
             label="Год рождения",
         )
         url_file_in_storage = serializers.URLField(read_only=True)


### PR DESCRIPTION
[Тикет](https://app.pachca.com/chats?thread_id=287026) (трэд в пачке)

Убраны ограничения по минимальному и максимальному значению для поля `year`.
Выход за установленные ограничения приводил к 500 ошибке на фронте.