### PR TITLE
Refactor image file handling when object is altered

### DIFF
--- a/apps/afisha/models/master_class.py
+++ b/apps/afisha/models/master_class.py
@@ -1,12 +1,13 @@
 from django.db import models
 
 from apps.content_pages.utilities import path_by_app_label_and_class_name
-from apps.core.mixins import image_clean_up_mixin_factory
+from apps.core.mixins import ImageCleanUpMixin
 from apps.core.models import BaseModel, Person
 from apps.library.utilities import get_team_roles
 
 
-class MasterClass(image_clean_up_mixin_factory(("main_image",)), BaseModel):
+class MasterClass(ImageCleanUpMixin, BaseModel):
+    cleanup_fields = ("main_image",)
     name = models.CharField(
         max_length=200,
         verbose_name="Название",

--- a/apps/afisha/models/master_class.py
+++ b/apps/afisha/models/master_class.py
@@ -1,11 +1,12 @@
 from django.db import models
 
 from apps.content_pages.utilities import path_by_app_label_and_class_name
+from apps.core.mixins import image_clean_up_mixin_factory
 from apps.core.models import BaseModel, Person
 from apps.library.utilities import get_team_roles
 
 
-class MasterClass(BaseModel):
+class MasterClass(image_clean_up_mixin_factory(("main_image",)), BaseModel):
     name = models.CharField(
         max_length=200,
         verbose_name="Название",

--- a/apps/afisha/models/performance.py
+++ b/apps/afisha/models/performance.py
@@ -7,14 +7,15 @@ from django.template.defaultfilters import truncatechars
 from apps.content_pages.querysets import PublishedContentQuerySet
 from apps.content_pages.utilities import path_by_app_label_and_class_name
 from apps.core.constants import AgeLimit, Status
-from apps.core.mixins import image_clean_up_mixin_factory
+from apps.core.mixins import ImageCleanUpMixin
 from apps.core.models import CORE_ROLES, BaseModel, Person
 from apps.library.utilities import get_team_roles
 
 User = get_user_model()
 
 
-class Performance(image_clean_up_mixin_factory(("main_image", "bottom_image")), BaseModel):
+class Performance(ImageCleanUpMixin, BaseModel):
+    cleanup_fields = ("main_image", "bottom_image")
     status = models.CharField(
         choices=Status.choices,
         default=Status.IN_PROCESS,

--- a/apps/afisha/models/performance.py
+++ b/apps/afisha/models/performance.py
@@ -7,14 +7,14 @@ from django.template.defaultfilters import truncatechars
 from apps.content_pages.querysets import PublishedContentQuerySet
 from apps.content_pages.utilities import path_by_app_label_and_class_name
 from apps.core.constants import AgeLimit, Status
+from apps.core.mixins import image_clean_up_mixin_factory
 from apps.core.models import CORE_ROLES, BaseModel, Person
-from apps.core.utils import delete_image_with_model
 from apps.library.utilities import get_team_roles
 
 User = get_user_model()
 
 
-class Performance(BaseModel):
+class Performance(image_clean_up_mixin_factory(("main_image", "bottom_image")), BaseModel):
     status = models.CharField(
         choices=Status.choices,
         default=Status.IN_PROCESS,
@@ -120,18 +120,6 @@ class Performance(BaseModel):
         if len(self.name) >= 25:
             return self.name[:25] + "..."
         return self.name
-
-    def save(self, *args, **kwargs):
-        this = Performance.objects.filter(id=self.id).first()
-        if this:
-            if this.main_image != self.main_image:
-                this.main_image.delete(save=False)
-            if this.bottom_image != self.bottom_image:
-                this.bottom_image.delete(save=False)
-        return super().save(*args, **kwargs)
-
-    def delete(self, *args, **kwargs):
-        delete_image_with_model(self, Performance, *args, **kwargs)
 
     @property
     def team(self):

--- a/apps/afisha/models/performance_media_review.py
+++ b/apps/afisha/models/performance_media_review.py
@@ -2,7 +2,7 @@ from django.db import models
 
 from apps.afisha.models import Performance
 from apps.content_pages.utilities import path_by_app_label_and_class_name
-from apps.core.mixins import image_clean_up_mixin_factory
+from apps.core.mixins import ImageCleanUpMixin
 from apps.core.models import BaseModel, Image
 
 
@@ -15,7 +15,8 @@ class PerformanceImage(Image):
     )
 
 
-class PerformanceMediaReview(image_clean_up_mixin_factory(("image",)), BaseModel):
+class PerformanceMediaReview(ImageCleanUpMixin, BaseModel):
+    cleanup_fields = ("image",)
     media_name = models.CharField(
         max_length=100,
         verbose_name="Название медиа ресурса",

--- a/apps/afisha/models/performance_media_review.py
+++ b/apps/afisha/models/performance_media_review.py
@@ -2,8 +2,8 @@ from django.db import models
 
 from apps.afisha.models import Performance
 from apps.content_pages.utilities import path_by_app_label_and_class_name
+from apps.core.mixins import image_clean_up_mixin_factory
 from apps.core.models import BaseModel, Image
-from apps.core.utils import delete_image_with_model
 
 
 class PerformanceImage(Image):
@@ -15,7 +15,7 @@ class PerformanceImage(Image):
     )
 
 
-class PerformanceMediaReview(BaseModel):
+class PerformanceMediaReview(image_clean_up_mixin_factory(("image",)), BaseModel):
     media_name = models.CharField(
         max_length=100,
         verbose_name="Название медиа ресурса",
@@ -54,16 +54,6 @@ class PerformanceMediaReview(BaseModel):
 
     def __str__(self):
         return self.media_name
-
-    def save(self, *args, **kwargs):
-        this = PerformanceMediaReview.objects.filter(id=self.id).first()
-        if this:
-            if this.image != self.image:
-                this.image.delete(save=False)
-        return super().save(*args, **kwargs)
-
-    def delete(self, *args, **kwargs):
-        delete_image_with_model(self, PerformanceMediaReview, *args, **kwargs)
 
 
 class PerformanceReview(BaseModel):

--- a/apps/afisha/models/reading.py
+++ b/apps/afisha/models/reading.py
@@ -1,11 +1,12 @@
 from django.db import models
 
 from apps.content_pages.utilities import path_by_app_label_and_class_name
+from apps.core.mixins import image_clean_up_mixin_factory
 from apps.core.models import CORE_ROLES, BaseModel, Person
 from apps.library.utilities import get_team_roles
 
 
-class Reading(BaseModel):
+class Reading(image_clean_up_mixin_factory(("main_image",)), BaseModel):
     play = models.ForeignKey(
         "library.Play",
         on_delete=models.PROTECT,

--- a/apps/afisha/models/reading.py
+++ b/apps/afisha/models/reading.py
@@ -1,12 +1,13 @@
 from django.db import models
 
 from apps.content_pages.utilities import path_by_app_label_and_class_name
-from apps.core.mixins import image_clean_up_mixin_factory
+from apps.core.mixins import ImageCleanUpMixin
 from apps.core.models import CORE_ROLES, BaseModel, Person
 from apps.library.utilities import get_team_roles
 
 
-class Reading(image_clean_up_mixin_factory(("main_image",)), BaseModel):
+class Reading(ImageCleanUpMixin, BaseModel):
+    cleanup_fields = ("main_image",)
     play = models.ForeignKey(
         "library.Play",
         on_delete=models.PROTECT,

--- a/apps/articles/models/blog_items.py
+++ b/apps/articles/models/blog_items.py
@@ -3,8 +3,8 @@ from django.db.models.constraints import UniqueConstraint
 
 from apps.content_pages.models import AbstractContent, AbstractContentPage
 from apps.content_pages.utilities import path_by_app_label_and_class_name
+from apps.core.mixins import image_clean_up_mixin_factory
 from apps.core.models import BaseModel, Person, Role
-from apps.core.utils import delete_image_with_model
 
 
 class BlogPerson(BaseModel):
@@ -47,7 +47,7 @@ class BlogPerson(BaseModel):
         return f"{self.role} - {self.person.full_name}"
 
 
-class BlogItem(AbstractContentPage):
+class BlogItem(image_clean_up_mixin_factory(("image",)), AbstractContentPage):
     author_url = models.URLField(
         verbose_name="Ссылка на автора записи",
     )
@@ -78,16 +78,6 @@ class BlogItem(AbstractContentPage):
 
     def __str__(self):
         return f"Запись блога {self.title}"
-
-    def save(self, *args, **kwargs):
-        this = BlogItem.objects.filter(id=self.id).first()
-        if this:
-            if this.image != self.image:
-                this.image.delete(save=False)
-        return super().save(*args, **kwargs)
-
-    def delete(self, *args, **kwargs):
-        delete_image_with_model(self, BlogItem, *args, **kwargs)
 
 
 class BlogItemContent(AbstractContent):

--- a/apps/articles/models/blog_items.py
+++ b/apps/articles/models/blog_items.py
@@ -3,7 +3,7 @@ from django.db.models.constraints import UniqueConstraint
 
 from apps.content_pages.models import AbstractContent, AbstractContentPage
 from apps.content_pages.utilities import path_by_app_label_and_class_name
-from apps.core.mixins import image_clean_up_mixin_factory
+from apps.core.mixins import ImageCleanUpMixin
 from apps.core.models import BaseModel, Person, Role
 
 
@@ -47,7 +47,8 @@ class BlogPerson(BaseModel):
         return f"{self.role} - {self.person.full_name}"
 
 
-class BlogItem(image_clean_up_mixin_factory(("image",)), AbstractContentPage):
+class BlogItem(ImageCleanUpMixin, AbstractContentPage):
+    cleanup_fields = ("image",)
     author_url = models.URLField(
         verbose_name="Ссылка на автора записи",
     )

--- a/apps/articles/models/news_items.py
+++ b/apps/articles/models/news_items.py
@@ -1,10 +1,12 @@
 from django.db import models
 
 from apps.content_pages.models import AbstractContent, AbstractContentPage
-from apps.core.mixins import image_clean_up_mixin_factory
+from apps.core.mixins import ImageCleanUpMixin
 
 
-class NewsItem(image_clean_up_mixin_factory(("image",)), AbstractContentPage):
+class NewsItem(ImageCleanUpMixin, AbstractContentPage):
+    cleanup_fields = ("image",)
+
     def __str__(self):
         return f"Новость {self.title}"
 

--- a/apps/articles/models/news_items.py
+++ b/apps/articles/models/news_items.py
@@ -1,10 +1,10 @@
 from django.db import models
 
 from apps.content_pages.models import AbstractContent, AbstractContentPage
-from apps.core.utils import delete_image_with_model
+from apps.core.mixins import image_clean_up_mixin_factory
 
 
-class NewsItem(AbstractContentPage):
+class NewsItem(image_clean_up_mixin_factory(("image",)), AbstractContentPage):
     def __str__(self):
         return f"Новость {self.title}"
 
@@ -17,16 +17,6 @@ class NewsItem(AbstractContentPage):
             ("access_level_2", "Права редактора"),
             ("access_level_3", "Права главреда"),
         )
-
-    def save(self, *args, **kwargs):
-        this = NewsItem.objects.filter(id=self.id).first()
-        if this:
-            if this.image != self.image:
-                this.image.delete(save=False)
-        return super().save(*args, **kwargs)
-
-    def delete(self, *args, **kwargs):
-        delete_image_with_model(self, NewsItem, *args, **kwargs)
 
 
 class NewsItemContent(AbstractContent):

--- a/apps/articles/models/projects.py
+++ b/apps/articles/models/projects.py
@@ -2,10 +2,10 @@ from django.db import models
 
 from apps.content_pages.models import AbstractContent, AbstractContentPage
 from apps.content_pages.utilities import path_by_app_label_and_class_name
-from apps.core.utils import delete_image_with_model
+from apps.core.mixins import image_clean_up_mixin_factory
 
 
-class Project(AbstractContentPage):
+class Project(image_clean_up_mixin_factory(("image",)), AbstractContentPage):
     image = models.ImageField(
         upload_to=path_by_app_label_and_class_name,
         verbose_name="Заглавная картинка",
@@ -36,16 +36,6 @@ class Project(AbstractContentPage):
             ("access_level_2", "Права редактора"),
             ("access_level_3", "Права главреда"),
         )
-
-    def save(self, *args, **kwargs):
-        this = Project.objects.filter(id=self.id).first()
-        if this:
-            if this.image != self.image:
-                this.image.delete(save=False)
-        return super().save(*args, **kwargs)
-
-    def delete(self, *args, **kwargs):
-        delete_image_with_model(self, Project, *args, **kwargs)
 
 
 class ProjectContent(AbstractContent):

--- a/apps/articles/models/projects.py
+++ b/apps/articles/models/projects.py
@@ -2,10 +2,11 @@ from django.db import models
 
 from apps.content_pages.models import AbstractContent, AbstractContentPage
 from apps.content_pages.utilities import path_by_app_label_and_class_name
-from apps.core.mixins import image_clean_up_mixin_factory
+from apps.core.mixins import ImageCleanUpMixin
 
 
-class Project(image_clean_up_mixin_factory(("image",)), AbstractContentPage):
+class Project(ImageCleanUpMixin, AbstractContentPage):
+    cleanup_fields = ("image",)
     image = models.ImageField(
         upload_to=path_by_app_label_and_class_name,
         verbose_name="Заглавная картинка",

--- a/apps/core/mixins.py
+++ b/apps/core/mixins.py
@@ -157,7 +157,13 @@ class GetDomainMixin:
 
 
 class ImageCleanUpMixin:
-    """Delete old image file when image is changed or deleted."""
+    """Delete old image file when image is changed or deleted.
+
+    Add the mixin to the model class parents and setup the
+    `cleanup_fields` tuple as the model's attribute, containing a sequence of
+    the model's ImageField field names, for which you want to delete the image
+    file after the field is altered.
+    """
 
     def save(self, *args, **kwargs):
         this = type(self).objects.filter(id=self.id).first()

--- a/apps/core/mixins.py
+++ b/apps/core/mixins.py
@@ -154,3 +154,27 @@ class GetDomainMixin:
 
     def prepend_domain(self, url):
         return get_domain(self.context["request"]) + str(url)
+
+
+def image_clean_up_mixin_factory(fields):
+    """Create image clean up mixin."""
+
+    class ImageCleanUpMixin:
+        def save(self, *args, **kwargs):
+            this = type(self).objects.filter(id=self.id).first()
+            if this:
+                for field in fields:
+                    this_field = getattr(this, field)
+                    if this_field != getattr(self, field):
+                        this_field.delete(save=False)
+
+            return super().save(*args, **kwargs)
+
+        def delete(self, *args, **kwargs):
+            for attr in (getattr(self, field) for field in fields):
+                storage, path = attr.storage, attr.path
+                super().delete(*args, **kwargs)
+                storage.delete(path)
+
+    assert type(fields) is not str, "fields must be a sequence of field names, not string"
+    return ImageCleanUpMixin

--- a/apps/core/models.py
+++ b/apps/core/models.py
@@ -8,7 +8,7 @@ from django.db.models import UniqueConstraint
 from django.utils.translation import gettext_lazy as _
 
 from apps.content_pages.utilities import path_by_app_label_and_class_name
-from apps.core.mixins import image_clean_up_mixin_factory
+from apps.core.mixins import ImageCleanUpMixin
 from apps.core.utils import slugify
 from apps.core.validators import email_validator
 
@@ -55,7 +55,8 @@ class Image(BaseModel):
         return self.image.url
 
 
-class Person(image_clean_up_mixin_factory(("image",)), BaseModel):
+class Person(ImageCleanUpMixin, BaseModel):
+    cleanup_fields = ("image",)
     first_name = models.CharField(
         max_length=50,
         verbose_name="Имя",
@@ -200,7 +201,9 @@ class RoleType(models.Model):
         return str(role_label)
 
 
-class Setting(image_clean_up_mixin_factory(("image",)), BaseModel):
+class Setting(ImageCleanUpMixin, BaseModel):
+    cleanup_fields = ("image",)
+
     class SettingGroup(models.TextChoices):
         EMAIL = "EMAIL", _("Почта")
         MAIN = "MAIN", _("Главная")

--- a/apps/info/models/festival.py
+++ b/apps/info/models/festival.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from apps.content_pages.utilities import path_by_app_label_and_class_name
-from apps.core.mixins import image_clean_up_mixin_factory
+from apps.core.mixins import ImageCleanUpMixin
 from apps.core.models import BaseModel, Image, Person
 
 
@@ -92,7 +92,8 @@ class FestTeamMember(FestivalTeamMember):
         verbose_name_plural = "Команда фестиваля"
 
 
-class Festival(image_clean_up_mixin_factory(("festival_image",)), BaseModel):
+class Festival(ImageCleanUpMixin, BaseModel):
+    cleanup_fields = ("festival_image",)
     start_date = models.DateField(verbose_name="Дата начала фестиваля")
     end_date = models.DateField(
         verbose_name="Дата окончания фестиваля",
@@ -227,7 +228,8 @@ class InfoLink(BaseModel):
         return self.title
 
 
-class PressRelease(image_clean_up_mixin_factory(("press_release_image",)), BaseModel):
+class PressRelease(ImageCleanUpMixin, BaseModel):
+    cleanup_fields = ("press_release_image",)
     text = RichTextField(
         config_name="press_release_styles",
         verbose_name="Текст",

--- a/apps/info/models/festival.py
+++ b/apps/info/models/festival.py
@@ -7,8 +7,8 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from apps.content_pages.utilities import path_by_app_label_and_class_name
+from apps.core.mixins import image_clean_up_mixin_factory
 from apps.core.models import BaseModel, Image, Person
-from apps.core.utils import delete_image_with_model
 
 
 class FestivalTeamMember(BaseModel):
@@ -92,7 +92,7 @@ class FestTeamMember(FestivalTeamMember):
         verbose_name_plural = "Команда фестиваля"
 
 
-class Festival(BaseModel):
+class Festival(image_clean_up_mixin_factory(("festival_image",)), BaseModel):
     start_date = models.DateField(verbose_name="Дата начала фестиваля")
     end_date = models.DateField(
         verbose_name="Дата окончания фестиваля",
@@ -167,14 +167,7 @@ class Festival(BaseModel):
 
     def save(self, *args, **kwargs):
         self.year = self.start_date.year
-        this = Festival.objects.filter(id=self.id).first()
-        if this:
-            if this.festival_image != self.festival_image:
-                this.festival_image.delete(save=False)
         return super().save(*args, **kwargs)
-
-    def delete(self, *args, **kwargs):
-        delete_image_with_model(self, Festival, *args, **kwargs)
 
     def clean(self):
         future_year = timezone.now().year + 1
@@ -234,7 +227,7 @@ class InfoLink(BaseModel):
         return self.title
 
 
-class PressRelease(BaseModel):
+class PressRelease(image_clean_up_mixin_factory(("press_release_image",)), BaseModel):
     text = RichTextField(
         config_name="press_release_styles",
         verbose_name="Текст",

--- a/apps/info/models/people.py
+++ b/apps/info/models/people.py
@@ -3,11 +3,12 @@ from django.db import models
 from django.db.models import UniqueConstraint
 from django.utils.translation import gettext_lazy as _
 
+from apps.core.mixins import image_clean_up_mixin_factory
 from apps.core.models import BaseModel, Person
 from apps.info.models.festival import Festival
 
 
-class Partner(BaseModel):
+class Partner(image_clean_up_mixin_factory(("image",)), BaseModel):
     class PartnerType(models.TextChoices):
         FESTIVAL_PARTNER = "festival", _("Партнер фестиваля")
         INFO_PARTNER = "info", _("Информационный партнер")
@@ -58,12 +59,6 @@ class Partner(BaseModel):
         verbose_name = "Партнер"
         verbose_name_plural = "Партнеры"
         ordering = ("order",)
-
-    def save(self, *args, **kwargs):
-        this = Partner.objects.filter(id=self.id).first()
-        if this and this.image != self.image:
-            this.image.delete(save=False)
-        super().save(*args, **kwargs)
 
     def __str__(self):
         return f"{self.name} - {self.type}"

--- a/apps/info/models/people.py
+++ b/apps/info/models/people.py
@@ -3,12 +3,14 @@ from django.db import models
 from django.db.models import UniqueConstraint
 from django.utils.translation import gettext_lazy as _
 
-from apps.core.mixins import image_clean_up_mixin_factory
+from apps.core.mixins import ImageCleanUpMixin
 from apps.core.models import BaseModel, Person
 from apps.info.models.festival import Festival
 
 
-class Partner(image_clean_up_mixin_factory(("image",)), BaseModel):
+class Partner(ImageCleanUpMixin, BaseModel):
+    cleanup_fields = ("image",)
+
     class PartnerType(models.TextChoices):
         FESTIVAL_PARTNER = "festival", _("Партнер фестиваля")
         INFO_PARTNER = "info", _("Информационный партнер")

--- a/apps/main/models.py
+++ b/apps/main/models.py
@@ -3,11 +3,13 @@ from django.db import models
 from django.utils.translation import gettext_lazy as _
 
 from apps.content_pages.utilities import path_by_app_label_and_class_name
-from apps.core.mixins import image_clean_up_mixin_factory
+from apps.core.mixins import ImageCleanUpMixin
 from apps.core.models import BaseModel, Setting
 
 
-class Banner(image_clean_up_mixin_factory(("image",)), BaseModel):
+class Banner(ImageCleanUpMixin, BaseModel):
+    cleanup_fields = ("image",)
+
     class ButtonType(models.TextChoices):
         TICKETS = "TICKETS", _("Билеты")
         DETAILS = "DETAILS", _("Подробнее")

--- a/apps/main/models.py
+++ b/apps/main/models.py
@@ -3,11 +3,11 @@ from django.db import models
 from django.utils.translation import gettext_lazy as _
 
 from apps.content_pages.utilities import path_by_app_label_and_class_name
+from apps.core.mixins import image_clean_up_mixin_factory
 from apps.core.models import BaseModel, Setting
-from apps.core.utils import delete_image_with_model
 
 
-class Banner(BaseModel):
+class Banner(image_clean_up_mixin_factory(("image",)), BaseModel):
     class ButtonType(models.TextChoices):
         TICKETS = "TICKETS", _("Билеты")
         DETAILS = "DETAILS", _("Подробнее")
@@ -53,16 +53,6 @@ class Banner(BaseModel):
     def clean(self):
         if Banner.objects.count() >= 3 and not self.id:
             raise ValidationError("Нельзя создать более 3-х банеров")
-
-    def save(self, *args, **kwargs):
-        this = Banner.objects.filter(id=self.id).first()
-        if this:
-            if this.image != self.image:
-                this.image.delete(save=False)
-        return super().save(*args, **kwargs)
-
-    def delete(self, *args, **kwargs):
-        delete_image_with_model(self, Banner, *args, **kwargs)
 
 
 class SettingGroupManager(models.Manager):


### PR DESCRIPTION
Тикет вашего PR (если есть):
    ___[При загрузке новой картинки старая не удаляется, а остаётся в приложении, причём доступна к скачиванию](https://www.notion.so/1b47bdf5dc1341e0aa1dba5013d7f44a)___

Продолжение PR https://github.com/Studio-Yandex-Practicum/Lubimovka_backend/pull/292

Удаление старого файла изображения при замене изображения или удалении объекта
- добавлено в модели Мастер-классы, Читки, Пресс-релиз
- приведено к единообразному виду в модели Блог, Новость, Проект, Спектакль, Медиа отзыв, Фестиваль, Партнер, Люди, Баннер на главной странице, настройки фото главной страницы, настройки изображения на первой странице