### PR TITLE
Use logical folder names when generating file name s for filer

### DIFF
--- a/apps/core/static/custom_filer.css
+++ b/apps/core/static/custom_filer.css
@@ -1,2 +1,8 @@
-form {display: none;}
+div.field-name {display: none;}
+div.field-owner {display: none;}
+div.field-description {display: none;}
+div.field-author {display: none;}
+div.field-default_alt_text {display: none;}
+div.field-default_caption {display: none;}
+
 div.image-preview-circle {display: none;}

--- a/apps/filer/utils.py
+++ b/apps/filer/utils.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+from django.utils.text import get_valid_filename
+
+from apps.core.utils import slugify
+
+
+def folder_slug(instance, filename):
+    filename_path = Path(filename)
+    return Path(
+        slugify(instance.logical_folder.name),
+        slugify(get_valid_filename(filename_path.stem)) + filename_path.suffix
+    )

--- a/apps/filer/utils.py
+++ b/apps/filer/utils.py
@@ -8,6 +8,5 @@ from apps.core.utils import slugify
 def folder_slug(instance, filename):
     filename_path = Path(filename)
     return Path(
-        slugify(instance.logical_folder.name),
-        slugify(get_valid_filename(filename_path.stem)) + filename_path.suffix
+        slugify(instance.logical_folder.name), slugify(get_valid_filename(filename_path.stem)) + filename_path.suffix
     )

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -370,6 +370,13 @@ SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 # DJANGO-FILER
 FILER_CANONICAL_URL = 'sharing/'
 FILER_ALLOW_REGULAR_USERS_TO_ADD_ROOT_FOLDERS = True
+FILER_STORAGES = {
+    'public': {
+        'main': {
+            'UPLOAD_TO': 'apps.filer.utils.folder_slug',
+        }
+    }
+}
 
 # Translations
 LOCALE_PATHS = [Path(STATIC_ROOT) / "core" / "locale", ]


### PR DESCRIPTION
Тикет вашего PR (если есть):
    ___[Filer. Удобочитаемые названия папок для файлов](https://www.notion.so/Filer-5c22dcf10b9f4d66b7c06f9a9303a01e)___

- реальный путь к файлам, создаваемым в разделе "Папки", основывается на их логическом пути
- для файла показывается форма изменения свойств с возможностью заменить файл